### PR TITLE
chore/login: implemented post api for login

### DIFF
--- a/Knowledgeable/cmd/server/main.go
+++ b/Knowledgeable/cmd/server/main.go
@@ -94,7 +94,10 @@ func main() {
 	)
 
 	http.HandleFunc("/logout", authHandler.Logout)
+
 	http.HandleFunc("/login", authHandler.Login)
+	
+	http.HandleFunc("/api/login", authHandler.LoginAPI)
 
 	http.Handle("/dashboard",
 		auth.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/Knowledgeable/internal/auth/handler.go
+++ b/Knowledgeable/internal/auth/handler.go
@@ -4,6 +4,7 @@ import (
 	"html/template"
 	"knowledgeable/internal/users"
 	"net/http"
+	"encoding/json"
 )
 
 type UserService interface {
@@ -99,4 +100,52 @@ func (h *Handler) Logout(w http.ResponseWriter, r *http.Request) {
 	})
 
 	http.Redirect(w, r, "/login", http.StatusSeeOther)
+}
+func (h *Handler) LoginAPI(w http.ResponseWriter, r *http.Request) {
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	type loginRequest struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+
+	var req loginRequest
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	if req.Username == "" || req.Password == "" {
+		http.Error(w, "missing credentials", http.StatusBadRequest)
+		return
+	}
+
+	user, err := h.userService.Login(req.Username, req.Password)
+	if err != nil {
+		http.Error(w, "invalid credentials", http.StatusUnauthorized)
+		return
+	}
+
+	sessionID := Create(user.ID)
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session_id",
+		Value:    sessionID,
+		SameSite: http.SameSiteLaxMode,
+		HttpOnly: true,
+		Path:     "/",
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":  "ok",
+		"message": "login successful",
+	})
 }


### PR DESCRIPTION
## What
Added JSON-based POST endpoint at /api/login to support programmatic authentication.

## Why
The new /api/login endpoint allows clients to authenticate using JSON payloads
and receive a valid session cookie without requiring browser-based navigation.
This enables automated load testing tools to establish authenticated sessions
before calling protected endpoints such as /api/search.

## Related Issue
Closes #

## Type 
- [] Feature
- [x] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)

