### PR TITLE
feature/add-makefile-for-dev-workflow

### DIFF
--- a/knowledgeable/Makefile
+++ b/knowledgeable/Makefile
@@ -1,0 +1,32 @@
+.PHONY: help test lint dev-up dev-down dev-build dev-logs setup-hooks
+
+help:
+	@echo Available targets:
+	@echo   make test
+	@echo   make lint
+	@echo   make dev-up
+	@echo   make dev-down
+	@echo   make dev-build
+	@echo   make dev-logs
+	@echo   make setup-hooks
+
+test:
+	go test ./...
+
+lint:
+	golangci-lint run
+
+dev-up:
+	docker compose -f docker-compose-dev.yml up -d
+
+dev-down:
+	docker compose -f docker-compose-dev.yml down
+
+dev-build:
+	docker compose -f docker-compose-dev.yml build
+
+dev-logs:
+	docker compose -f docker-compose-dev.yml logs -f
+
+setup-hooks:
+	setup-hooks.sh

--- a/setup-hooks
+++ b/setup-hooks
@@ -1,0 +1,22 @@
+#!/bin/sh
+# setup-hooks.sh
+# Configures the repo to use the version-controlled githooks directory
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOKS_DIR="$REPO_ROOT/githooks"
+
+echo "Configuring Git hooks..."
+
+# Tell git to use the githooks directory
+git config core.hooksPath githooks
+
+# Ensure hooks are executable
+chmod +x "$HOOKS_DIR"/*
+
+echo ""
+echo "Hooks enabled from: $HOOKS_DIR"
+echo ""
+echo "Available hooks:"
+ls "$HOOKS_DIR"


### PR DESCRIPTION
## What

## Why
Why is this change needed?

Added a Makefile to standardize the development workflow.

The Makefile includes commands for:

running Go tests

running golangci-lint

managing the development Docker environment

installing Git hooks for linting before commits

What has been implemented?
Added Makefile that simplifies and standardizes common development tasks. Developers now dont have to memorize the individual commands, but has a Makefile interfaces that makes it much easier.
## Related Issue
Closes #105 

## Type 
- [x] Feature
- [] Bug
- [] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)

