### PR TITLE
chore(infra): added redundant CI workflow run on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: Go CI
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
## What
What has been implemented?
Removed the push trigger in ci worfklow
## Why
Why is this change needed?
avoid unnecessary duplicate run. now the workflow only runs with PR
## Related Issue
Closes #171 

## Type 
- [] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)

