### PR TITLE
fix(gosec): removed illegal -v flag

### DIFF
--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -31,13 +31,14 @@ jobs:
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
         with:
-          args: '-no-fail -fmt sarif -out results.sarif -v ./knowledgeable/...'
+          args: '-no-fail -fmt sarif -out results.sarif ./knowledgeable/...'
+
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif
-          
+
       - name: Save SARIF as artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## What
removed -v flag in gosec

## Why
it is illegal

## Related Issue
Closes #

## Type 
- [] Feature
- [x] Bug
- [] Chore
- [] Docs

## Definition of Done
- [] Code implemented
- [] Tests added (if relevant)

