### PR TITLE
chore(makefile): added dev-migrate target and dev-init wrapper

### DIFF
--- a/knowledgeable/Makefile
+++ b/knowledgeable/Makefile
@@ -20,7 +20,11 @@ lint:
 
 dev-up:
 	docker compose -f docker-compose-dev.yml up -d
-	
+
+dev-migrate:
+	docker compose -f docker-compose-dev.yml run --rm migrations sh -c "npm install && npx knex migrate:latest && npx knex seed:run"
+
+dev-init: dev-up dev-migrate
 
 dev-down:
 	docker compose -f docker-compose-dev.yml down


### PR DESCRIPTION
## What
Added make targets

## Why
Allowing migrations to be executed as a standalone step and optionally combined via `dev-init`.


## Related Issue
Closes #

## Type 
- [] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)

