### PR TITLE
chore(dev): changed make dev-up to run migration automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,13 @@ jobs:
       - name: Build
         run: go build ./...
 
+      - name: Run database migrations
+        run: |
+          docker compose -f docker-compose-dev.yml run --rm migrations sh -c "npm install && npx knex migrate:latest && npx knex seed:run"
+
+      - name: Tear down migration containers
+        if: always()
+        run: docker compose -f docker-compose-dev.yml down
+
       - name: Test
         run: go test -v ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ jobs:
       - name: Build
         run: go build ./...
 
+      - name: Start database
+        run: docker compose -f docker-compose-dev.yml up -d db
+
+      - name: Wait for database
+        run: |
+          timeout 60 bash -c 'until docker compose -f docker-compose-dev.yml exec -T db pg_isready -U user; do sleep 2; done'
+
       - name: Run database migrations
         run: |
           docker compose -f docker-compose-dev.yml run --rm migrations sh -c "npm install && npx knex migrate:latest && npx knex seed:run"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,9 @@ jobs:
         run: |
           docker compose -f docker-compose-dev.yml run --rm migrations sh -c "npm install && npx knex migrate:latest && npx knex seed:run"
 
+      - name: Test
+        run: go test -v ./...
+
       - name: Tear down migration containers
         if: always()
         run: docker compose -f docker-compose-dev.yml down
-
-      - name: Test
-        run: go test -v ./...

--- a/knowledgeable/Makefile
+++ b/knowledgeable/Makefile
@@ -20,11 +20,10 @@ lint:
 
 dev-up:
 	docker compose -f docker-compose-dev.yml up -d
+	$(MAKE) dev-migrate
 
 dev-migrate:
 	docker compose -f docker-compose-dev.yml run --rm migrations sh -c "npm install && npx knex migrate:latest && npx knex seed:run"
-
-dev-init: dev-up dev-migrate
 
 dev-down:
 	docker compose -f docker-compose-dev.yml down

--- a/knowledgeable/Makefile
+++ b/knowledgeable/Makefile
@@ -20,6 +20,7 @@ lint:
 
 dev-up:
 	docker compose -f docker-compose-dev.yml up -d
+	docker compose -f docker-compose-dev.yml exec -T db sh -c 'until pg_isready -U user; do sleep 2; done'
 	$(MAKE) dev-migrate
 
 dev-migrate:

--- a/knowledgeable/docker-compose-dev.yml
+++ b/knowledgeable/docker-compose-dev.yml
@@ -33,6 +33,11 @@ services:
     working_dir: /workspace/db-migrations
     volumes:
     - .:/workspace
+    environment:
+      POSTGRES_DB: knowledge
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_HOST: db
     depends_on:
     - db
   frontend:


### PR DESCRIPTION
## What
Changed make dev-up target to run migration automatically

## Why
For better flow 

## Related Issue
Closes #

## Type 
- [] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Dev environment startup now waits for the database to be ready and runs schema migrations automatically as part of the single startup command, removing the separate init entry point.
  * CI now provisions a database, waits for readiness, runs migrations and seeds during the workflow, and always tears down the test environment afterward to ensure a clean state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->