### PR TITLE
Chore/migrations postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
       GO111MODULE: on
       GOPRIVATE: github.com/knowledgeables/*
       GITHUB_AUTHENTICATION_TOKEN: ${{ secrets.CR__PAT }}
+      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
     defaults:
       run:
@@ -41,7 +44,7 @@ jobs:
 
       - name: Wait for database
         run: |
-          timeout 60 bash -c 'until docker compose -f docker-compose-dev.yml exec -T db pg_isready -U user; do sleep 2; done'
+          timeout 60 bash -c 'until docker compose -f docker-compose-dev.yml exec -T db pg_isready -U "${POSTGRES_USER:-user}"; do sleep 2; done'
 
       - name: Run database migrations
         run: |

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -8,6 +8,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
     permissions:
       contents: read
       packages: write
@@ -30,7 +35,7 @@ jobs:
       - name: Wait for database
         working-directory: knowledgeable
         run: |
-          timeout 60 bash -c 'until docker compose -f docker-compose-dev.yml exec -T db pg_isready -U user; do sleep 2; done'
+          timeout 60 bash -c 'until docker compose -f docker-compose-dev.yml exec -T db pg_isready -U "${POSTGRES_USER:-user}"; do sleep 2; done'
 
       - name: Run database migrations
         working-directory: knowledgeable

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -26,11 +26,23 @@ jobs:
             knowledgeable/docker-compose-prod.yml \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/app/docker-compose.yml
 
+      - name: Write remote production .env
+        run: |
+          ssh -i ~/.ssh/ssh_key -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} << 'EOF'
+            cat > ~/app/.env << 'EOENV'
+            POSTGRES_USER=${{ secrets.POSTGRES_USER }}
+            POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+            DATABASE_URL=${{ secrets.DATABASE_URL }}
+            EOENV
+          EOF
+
       - name: Deploy on server
         run: |
           ssh -i ~/.ssh/ssh_key -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} << "EOF"
             echo "${{ secrets.CR__PAT }}" | docker login ghcr.io -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
             cd ~/app
-            docker compose pull app
-            docker compose up -d --no-deps app
+            docker compose pull app db migrations
+            docker compose up -d db app
+            timeout 60 bash -c "until docker compose exec -T db pg_isready -U '${POSTGRES_USER}'; do sleep 2; done"
+            docker compose run --rm migrations npx knex migrate:latest
           EOF

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,6 +10,12 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
 
+    env:
+      POSTGRES_DB: knowledge
+      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
@@ -26,17 +32,12 @@ jobs:
     
     - name: Wait for database
       working-directory: knowledgeable
-      run: timeout 60 bash -c 'until docker compose -f docker-compose-dev.yml exec -T db pg_isready -U user; do sleep 2; done'
+      run: timeout 60 bash -c 'until docker compose -f docker-compose-dev.yml exec -T db pg_isready -U "${POSTGRES_USER}"; do sleep 2; done'
     
     - name: Run migrations + seeds
       working-directory: knowledgeable
       run: |
-        docker compose -f docker-compose-dev.yml run --rm \
-        -e POSTGRES_DB=knowledge \
-        -e POSTGRES_USER=user \
-        -e POSTGRES_PASSWORD=password \
-        -e POSTGRES_HOST=db \
-        migrations sh -c "npm install && npx knex migrate:latest && npx knex seed:run"
+        docker compose -f docker-compose-dev.yml run --rm migrations sh -c "npm install && npx knex migrate:latest && npx knex seed:run"
 
     - name: Install dependencies
       working-directory: knowledgeable

--- a/knowledgeable/Dockerfile.migrations
+++ b/knowledgeable/Dockerfile.migrations
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY db-migrations/package*.json db-migrations/
+RUN npm install --prefix db-migrations
+
+COPY db-migrations db-migrations
+
+WORKDIR /app/db-migrations
+
+CMD ["npx", "knex", "--help"]

--- a/knowledgeable/Makefile
+++ b/knowledgeable/Makefile
@@ -19,12 +19,12 @@ lint:
 	golangci-lint run
 
 dev-up:
-	docker compose -f docker-compose-dev.yml up -d
-	docker compose -f docker-compose-dev.yml exec -T db sh -c 'until pg_isready -U user; do sleep 2; done'
+	docker compose --env-file .env -f docker-compose-dev.yml up -d
+	docker compose --env-file .env -f docker-compose-dev.yml exec -T db sh -c 'until pg_isready -U $$POSTGRES_USER; do sleep 2; done'
 	$(MAKE) dev-migrate
 
 dev-migrate:
-	docker compose -f docker-compose-dev.yml run --rm migrations sh -c "npm install && npx knex migrate:latest && npx knex seed:run"
+	docker compose --env-file .env -f docker-compose-dev.yml run --rm migrations sh -c "npm install && npx knex migrate:latest && npx knex seed:run"
 
 dev-down:
 	docker compose -f docker-compose-dev.yml down

--- a/knowledgeable/docker-compose-build.yml
+++ b/knowledgeable/docker-compose-build.yml
@@ -5,6 +5,12 @@ services:
       context: .
       dockerfile: Dockerfile.prod
 
+  migrations:
+    image: ghcr.io/knowledgeables/knowledge-migrations:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.migrations
+
   nginx:
     image: ghcr.io/knowledgeables/knowledge_nginx:latest
     build:

--- a/knowledgeable/docker-compose-dev.yml
+++ b/knowledgeable/docker-compose-dev.yml
@@ -5,8 +5,8 @@ services:
     restart: always
     environment:
       POSTGRES_DB: knowledge
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: password
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
       - "5432:5432"
     volumes:
@@ -25,7 +25,7 @@ services:
 
     environment:
       APP_ENV: dev
-      DATABASE_URL: postgres://user:password@db:5432/knowledge?sslmode=disable
+      DATABASE_URL: ${DATABASE_URL}
     depends_on:
       - db
   migrations:
@@ -35,8 +35,8 @@ services:
     - .:/workspace
     environment:
       POSTGRES_DB: knowledge
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: password
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_HOST: db
     depends_on:
     - db

--- a/knowledgeable/docker-compose-prod.yml
+++ b/knowledgeable/docker-compose-prod.yml
@@ -1,13 +1,38 @@
 services:
+  db:
+    image: postgres:15
+    container_name: postgres_db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: knowledge
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - knowledgeable_network
+
   app:
     image: ghcr.io/knowledgeables/knowledge:latest
     container_name: knowledgeable
     restart: unless-stopped
     environment:
-      DB_PATH: /app/data/prod.db
       APP_ENV: production
-    volumes:
-      - ./data:/app/data
+      DATABASE_URL: ${DATABASE_URL}
+    depends_on:
+      - db
+    networks:
+      - knowledgeable_network
+
+  migrations:
+    image: ghcr.io/knowledgeables/knowledge-migrations:latest
+    depends_on:
+      - db
+    environment:
+      POSTGRES_DB: knowledge
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_HOST: db
     networks:
       - knowledgeable_network
 
@@ -40,3 +65,6 @@ services:
 networks:
   knowledgeable_network:
     driver: bridge
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## What
- Updated GitHub workflows to use Postgres secrets and remove hardcoded DB credentials
- Added migration container support and local dev makefile env loading
Ensured deployment writes remote .env , waits for Postgres, and runs migrations
## Why
Why is this change needed?
So all environments use the same Postgres migration flow
To avoid hardcoded DB credentials in CI / Playwright / deployment
To keep local dev config explicit and consistent with Compose env requirements
To ensure production applies migrations during deploy
## Related Issue
Closes #

## Type 
- [] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database credential management through environment variable configuration across CI/CD workflows and Docker environments.
  * Introduced a dedicated migrations service for enhanced database schema management.
  * Enhanced Docker Compose configurations for development and production environments with better service orchestration and dependency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->