### PR TITLE
chore(cd): added extra _ to secrets.cr_pat to match github secrets

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -33,7 +33,7 @@ jobs:
 
           set -e
 
-          echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+          echo "${{ secrets.CR__PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
           cd ~/app
 


### PR DESCRIPTION
## What
What has been implemented?
Added extra "_" to deployment.yml to match github secrets.
## Why
Why is this change needed?
in the last workflow it didnt deploy because there is a typo in the github secrets.
## Related Issue


## Type 
- [] Feature
- [x] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [x] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow authentication configuration to ensure continued secure deployment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->