### PR TITLE
Feat/e2e/staging/full suit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Go CI
+name: CI - Lint, Build, Test
 
 on:
   pull_request:

--- a/.github/workflows/playwright_ci.yml
+++ b/.github/workflows/playwright_ci.yml
@@ -1,4 +1,4 @@
-name: Playwright Tests
+name: CI - Playwright Smoke Test
 on:
   pull_request:
     branches: [main]

--- a/knowledgeable/docker-compose-staging.yml
+++ b/knowledgeable/docker-compose-staging.yml
@@ -1,6 +1,7 @@
 services:
   db:
     image: postgres:16
+    container_name: postgres_staging_db
     restart: unless-stopped
     environment:
       POSTGRES_DB: knowledgeable
@@ -10,18 +11,13 @@ services:
       - postgres_data_staging:/var/lib/postgresql/data
     networks:
       - staging
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d knowledgeable"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
 
   migrations:
     image: ghcr.io/knowledgeables/knowledge-migrations:latest
-    profiles: ["tools"]
     depends_on:
-      db:
-        condition: service_healthy
+      - db
+    restart: "no"
+    profiles: ["tools"]
     environment:
       POSTGRES_DB: knowledgeable
       POSTGRES_USER: postgres
@@ -32,13 +28,17 @@ services:
 
   app:
     image: ghcr.io/knowledgeables/knowledge:latest
+    container_name: knowledgeable_app_staging
+    depends_on:
+      - db
     restart: unless-stopped
     environment:
-      DATABASE_URL: postgres://postgres:postgres@db:5432/knowledgeable?sslmode=disable
+      POSTGRES_DB: knowledgeable
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_HOST: db
       APP_ENV: staging
-    depends_on:
-      db:
-        condition: service_healthy
+      DATABASE_URL: postgres://postgres:postgres@db:5432/knowledgeable?sslmode=disable
     ports:
       - "8081:8080"
     networks:
@@ -50,3 +50,6 @@ volumes:
 networks:
   staging:
     driver: bridge
+
+
+# Last updated: deployed via CD pipeline

--- a/knowledgeable/docker-compose-staging.yml
+++ b/knowledgeable/docker-compose-staging.yml
@@ -11,11 +11,17 @@ services:
       - postgres_data_staging:/var/lib/postgresql/data
     networks:
       - staging
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d knowledgeable"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
   migrations:
     image: ghcr.io/knowledgeables/knowledge-migrations:latest
     depends_on:
-      - db
+        db:
+          condition: service_healthy
     restart: "no"
     profiles: ["tools"]
     environment:
@@ -30,7 +36,8 @@ services:
     image: ghcr.io/knowledgeables/knowledge:latest
     container_name: knowledgeable_app_staging
     depends_on:
-      - db
+        db:
+          condition: service_healthy
     restart: unless-stopped
     environment:
       POSTGRES_DB: knowledgeable
@@ -52,4 +59,3 @@ networks:
     driver: bridge
 
 
-# Last updated: deployed via CD pipeline


### PR DESCRIPTION
## What
What has been implemented?
- changed docker-compose-staging.yml to the truthy one in vm. further more added scp in the deploy_staging.yml to always have source of truth in repository
- changed name for playwright smoketest to match workflow naming convention
-  changed name for ci to match naming convention with cd workflows
## Why
Why is this change needed?
Needs single source of truth and correct naming convention in order to prepare for full suit test in staging environment.
## Related Issue
Closes #

## Type 
- [] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed CI workflow labels for clarity: "Go CI" → "CI - Lint, Build, Test" and "Playwright Tests" → "CI - Playwright Smoke Test".
  * Updated staging deployment configuration: explicit container names, adjusted service startup/dependency behavior, expanded DB environment variables, and added restart policy; file ending whitespace updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->