### PR TITLE
chore(cd): changed deploy_staging.yml

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -51,21 +51,15 @@ jobs:
             timeout 60 bash -c 'until docker compose -p staging -f docker-compose-staging.yml exec -T db pg_isready -U postgres -d knowledgeable; do sleep 2; done'
 
 
-            echo "[DEPLOY] Running migrations"
-            docker compose -p staging -f docker-compose-staging.yml --profile tools run --rm migrations \
-              sh -c "
-                echo '[MIGRATION] Running migrations...'
-                until npx knex migrate:latest; do
-                  echo '[MIGRATION] Retrying...'
-                  sleep 3
-                done
-              "
+            echo "[DEPLOY] Run migrations"
+            docker compose -p staging -f docker-compose-staging.yml --profile tools run --rm migrations npx knex migrate:latest
 
-            echo "[DEPLOY] Starting APP"
-            docker compose -p staging -f docker-compose-staging.yml up -d app
+            echo "[DEPLOY] Start app"
+            docker compose  -p staging -f docker-compose-staging.yml up -d --remove-orphans app 
 
             echo "[DEPLOY] Checking containers"
             docker compose -p staging -f docker-compose-staging.yml ps
 
             echo "[DEPLOY] Staging deploy completed"
+
             EOF


### PR DESCRIPTION
…gration because of EOF

## What
What has been implemented?
changed deploy-staging.yml as it stopped before migration because of EOF. removed the scp script and added docker compose command instead.
## Why
Why is this change needed?
staging never ran migration service
## Related Issue
Closes #

## Type 
- [] Feature
- [x] Bug
- [] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified staging deployment workflow to improve reliability and reduce complexity in the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->