### PR TITLE
chore(cd): removed timeout in 'wait for db' command

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -48,7 +48,7 @@ jobs:
             docker compose -p staging -f docker-compose-staging.yml up -d db   
           
             echo "[DEPLOY] Wait for DB"
-            timeout 60 bash -c 'until docker compose -p staging -f docker-compose-staging.yml exec -T db pg_isready -U postgres -d knowledgeable; do sleep 2; done'
+            until docker compose -p staging -f docker-compose-staging.yml exec -T db pg_isready -U postgres -d knowledgeable; do sleep 2; done
 
 
             echo "[DEPLOY] Run migrations"
@@ -62,3 +62,4 @@ jobs:
 
             echo "[DEPLOY] Staging deploy completed"
          EOF
+         

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -48,8 +48,15 @@ jobs:
             docker compose -p staging -f docker-compose-staging.yml up -d db   
           
             echo "[DEPLOY] Wait for DB"
-            until docker compose -p staging -f docker-compose-staging.yml exec -T db pg_isready -U postgres -d knowledgeable; do sleep 2; done
+            for i in {1..30}; do
+              if docker compose -p staging -f docker-compose-staging.yml exec -T db pg_isready -U postgres -d knowledgeable; then
+                echo "[DEPLOY] DB ready"
+                break
+              fi
+              sleep 2
+              done      
 
+            docker compose -p staging -f docker-compose-staging.yml exec -T db pg_isready -U postgres -d knowledgeable
 
             echo "[DEPLOY] Run migrations"
             docker compose -p staging -f docker-compose-staging.yml --profile tools run --rm migrations npx knex migrate:latest


### PR DESCRIPTION
## What
What has been implemented?
 as it might result in exit code and stop the workflow entirely
## Why
Why is this change needed?
need to start migration in the cd staging workflow.


## Type 
- [] Feature
- [x] Bug
- [] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved staging deployment reliability by replacing the fixed timeout with a more resilient, repeated database readiness check that retries before proceeding.
  * Made a minor adjustment to the deployment script’s remote execution handling to ensure consistent behavior during staging runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->