### PR TITLE
feat(cd): added changes to keep migration container alive for promtai…

### DIFF
--- a/.github/scripts/deploy-staging.sh
+++ b/.github/scripts/deploy-staging.sh
@@ -24,7 +24,8 @@ if [ "$DB_READY" -eq 0 ]; then
   exit 1
 fi
 echo "[DEPLOY] Run migrations"
-docker compose -p staging -f docker-compose-staging.yml --profile tools run --rm migrations
+docker compose -p staging -f docker-compose-staging.yml --profile tools run migrations
+docker compose -p staging -f docker-compose-staging.yml --profile tools rm -f migrations
 echo "[DEPLOY] Start app"
 docker compose -p staging -f docker-compose-staging.yml up -d --remove-orphans app
 echo "[DEPLOY] Checking containers"

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -26,12 +26,12 @@ jobs:
             knowledgeable/docker-compose-staging.yml \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/app/docker-compose-staging.yml
 
-      - name: Copy deploy script
+      - name: Copy staging deploy script
         run: |
-          scp -i ~/.ssh/ssh_key -o StrictHostKeyChecking=no .github/scripts/deploy-staging.sh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/app/deploy.sh
+          scp -i ~/.ssh/ssh_key -o StrictHostKeyChecking=no .github/scripts/deploy-staging.sh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/app/deploy-staging.sh
       
       - name: Deploy staging
         run: |
           ssh -i ~/.ssh/ssh_key -o StrictHostKeyChecking=no \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
-            "CR_PAT='${{ secrets.CR__PAT }}' DOCKER_USERNAME='${{ secrets.DOCKER_USERNAME }}' bash ~/app/deploy.sh"
+            "CR_PAT='${{ secrets.CR__PAT }}' DOCKER_USERNAME='${{ secrets.DOCKER_USERNAME }}' bash ~/app/deploy-staging.sh"

--- a/.github/workflows/playwright_staging.yml
+++ b/.github/workflows/playwright_staging.yml
@@ -1,0 +1,8 @@
+name: CD - Playwright Staging
+on:
+  workflow_dispatch:
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Not implemented yet"


### PR DESCRIPTION
## What
Removed `--rm` from migrations run command and added explicit cleanup step after migrations complete.

## Why
Promtail uses Docker socket discovery with a 5s refresh interval. With `--rm` the container was destroyed before Promtail could discover it and collect logs. Keeping the container alive until explicit cleanup ensures migration logs are shipped to Loki.

## Related Issue
Closes #

## Type
- [] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging deployment script execution and container cleanup process
  * Added placeholder for future staging test automation workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->