### PR TITLE
feat(users): added force change password for all users

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(xargs wc *)",
+      "Bash(go build *)"
+    ]
+  }
+}

--- a/knowledgeable/Makefile
+++ b/knowledgeable/Makefile
@@ -25,7 +25,7 @@ dev-up:
 	$(MAKE) dev-migrate
 
 dev-migrate:
-	docker compose -f docker-compose-dev.yml run --rm migrations sh -c "npx knex migrate:latest && npx knex seed:run --specific=dev_init_data.js"
+	docker compose -f docker-compose-dev.yml run --rm migrations sh -c "npm install && npx knex migrate:latest && npx knex seed:run --specific=dev_init_data.js"
 
 dev-down:
 	docker compose -f docker-compose-dev.yml down

--- a/knowledgeable/db-migrations/migrations/20260418000000_add_should_change_password.js
+++ b/knowledgeable/db-migrations/migrations/20260418000000_add_should_change_password.js
@@ -1,0 +1,13 @@
+export function up(knex) {
+  return knex.schema
+    .table('users', (table) => {
+      table.boolean('should_change_password').notNullable().defaultTo(false);
+    })
+    .then(() => knex('users').update({ should_change_password: true }));
+}
+
+export function down(knex) {
+  return knex.schema.table('users', (table) => {
+    table.dropColumn('should_change_password');
+  });
+}

--- a/knowledgeable/db-migrations/seeds/dev_init_data.js
+++ b/knowledgeable/db-migrations/seeds/dev_init_data.js
@@ -9,12 +9,14 @@ export async function seed(knex) {
       {
         username: 'admin',
         email: 'admin@dev.local',
-        password_hash: '$2a$12$8fhiDpxQAlrTsZfQYLiKUeELzXABImIynuZSx3nwyNfIOofEg1W3i'       
+        password_hash: '$2a$12$8fhiDpxQAlrTsZfQYLiKUeELzXABImIynuZSx3nwyNfIOofEg1W3i',
+        should_change_password: true
       },
       {
         username: 'tester',
         email: 'tester@dev.local',
-        password_hash: '$2a$12$sHphNz2knALIBeijiWoCqe3erFOhSY/Ke8kUt/09g3SkRySl0kTp2'
+        password_hash: '$2a$12$sHphNz2knALIBeijiWoCqe3erFOhSY/Ke8kUt/09g3SkRySl0kTp2',
+        should_change_password: true
       }
     ])
     .onConflict(['email'])

--- a/knowledgeable/db-migrations/seeds/staging_init_data.js
+++ b/knowledgeable/db-migrations/seeds/staging_init_data.js
@@ -15,13 +15,15 @@ export async function seed(knex) {
         username: 'e2e_user',
         email: 'e2e@staging.local',
         // password: "password123"
-        password_hash: '$2a$12$wH8Q8G0dQ2Q0qV2c9l6s2e2rG9x0k7v5n8wYcV3f7u9l6qQ8bG3y2'
+        password_hash: '$2a$12$wH8Q8G0dQ2Q0qV2c9l6s2e2rG9x0k7v5n8wYcV3f7u9l6qQ8bG3y2',
+        should_change_password: true
       },
       {
         username: 'admin',
         email: 'admin@staging.local',
         // password: "admin123"
-        password_hash: '$2a$12$8fhiDpxQAlrTsZfQYLiKUeELzXABImIynuZSx3nwyNfIOofEg1W3i'
+        password_hash: '$2a$12$8fhiDpxQAlrTsZfQYLiKUeELzXABImIynuZSx3nwyNfIOofEg1W3i',
+        should_change_password: true
       }
     ])
 

--- a/knowledgeable/internal/auth/auth_integration_test.go
+++ b/knowledgeable/internal/auth/auth_integration_test.go
@@ -24,6 +24,10 @@ func (s *successUserService) GetByID(id int64) (*users.User, error) {
 	}, nil
 }
 
+func (s *successUserService) ChangePassword(userID int64, newPassword string) error {
+	return nil
+}
+
 // HAPPY PATH
 func TestLoginAPI_SetsSessionCookie(t *testing.T) {
 
@@ -97,6 +101,10 @@ func (s *failUserService) Login(username, password string) (*users.User, error) 
 
 func (s *failUserService) GetByID(id int64) (*users.User, error) {
 	return nil, errors.New("user not found")
+}
+
+func (s *failUserService) ChangePassword(userID int64, newPassword string) error {
+	return errors.New("change password failed")
 }
 
 func TestLoginAPI_InvalidCredentials(t *testing.T) {

--- a/knowledgeable/internal/auth/handler.go
+++ b/knowledgeable/internal/auth/handler.go
@@ -27,6 +27,7 @@ type MeResponse struct {
 type UserService interface {
 	Login(string, string) (*users.User, error)
 	GetByID(id int64) (*users.User, error)
+	ChangePassword(userID int64, newPassword string) error
 }
 
 type Handler struct {
@@ -156,7 +157,73 @@ func (h *Handler) LoginAPI(w http.ResponseWriter, r *http.Request) {
 		Secure:   os.Getenv("APP_ENV") != "dev",
 	})
 
+	if user.ShouldChangePassword {
+		http.Redirect(w, r, "/change-password", http.StatusSeeOther)
+		return
+	}
+
 	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+// ChangePassword godoc
+// @Summary Change password
+// @Description Force-change password for authenticated user
+// @Tags auth
+// @Produce html
+// @Success 303 {string} string "Redirect to home"
+// @Failure 400 {string} string "bad request"
+// @Failure 401 {string} string "unauthorized"
+// @Router /change-password [get,post]
+func (h *Handler) ChangePassword(w http.ResponseWriter, r *http.Request) {
+	cookie, err := r.Cookie("session_id")
+	if err != nil {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+
+	userID, ok := Get(cookie.Value)
+	if !ok {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+
+	if r.Method == http.MethodGet {
+		tmpl := h.loadTmpl()
+		if err := tmpl.ExecuteTemplate(w, "change_password.html", nil); err != nil {
+			http.Error(w, "template error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	if r.Method == http.MethodPost {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		password := strings.TrimSpace(r.FormValue("password"))
+		confirm := strings.TrimSpace(r.FormValue("confirm_password"))
+
+		if password == "" || confirm == "" {
+			http.Error(w, "missing fields", http.StatusBadRequest)
+			return
+		}
+
+		if password != confirm {
+			http.Error(w, "passwords do not match", http.StatusBadRequest)
+			return
+		}
+
+		if err := h.userService.ChangePassword(userID, password); err != nil {
+			http.Error(w, "failed to change password", http.StatusInternalServerError)
+			return
+		}
+
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+		return
+	}
+
+	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 }
 
 // Me godoc

--- a/knowledgeable/internal/users/model.go
+++ b/knowledgeable/internal/users/model.go
@@ -2,8 +2,9 @@ package users
 
 
 type User struct {
-	ID           int64
-	Username     string
-	Email        string
-	PasswordHash string
+	ID                   int64
+	Username             string
+	Email                string
+	PasswordHash         string
+	ShouldChangePassword bool
 }

--- a/knowledgeable/internal/users/repository.go
+++ b/knowledgeable/internal/users/repository.go
@@ -31,12 +31,12 @@ func (r *Repository) Register(user *User) error {
 
 func (r *Repository) FindByUsername(username string) (*User, error) {
 	row := r.db.QueryRow(
-		"SELECT id, username, email, password_hash FROM users WHERE username = $1",
+		"SELECT id, username, email, password_hash, should_change_password FROM users WHERE username = $1",
 		username,
 	)
 
 	var user User
-	err := row.Scan(&user.ID, &user.Username, &user.Email, &user.PasswordHash)
+	err := row.Scan(&user.ID, &user.Username, &user.Email, &user.PasswordHash, &user.ShouldChangePassword)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -51,12 +51,12 @@ func (r *Repository) FindByUsername(username string) (*User, error) {
 
 func (r *Repository) FindById(id int64) (*User, error) {
 	row := r.db.QueryRow(
-		"SELECT id, username, email, password_hash FROM users WHERE id = $1",
+		"SELECT id, username, email, password_hash, should_change_password FROM users WHERE id = $1",
 		id,
 	)
 
 	var user User
-	err := row.Scan(&user.ID, &user.Username, &user.Email, &user.PasswordHash)
+	err := row.Scan(&user.ID, &user.Username, &user.Email, &user.PasswordHash, &user.ShouldChangePassword)
 
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -67,6 +67,14 @@ func (r *Repository) FindById(id int64) (*User, error) {
 	}
 
 	return &user, nil
+}
+
+func (r *Repository) UpdatePassword(userID int64, newPasswordHash string) error {
+	_, err := r.db.Exec(
+		"UPDATE users SET password_hash = $1, should_change_password = false WHERE id = $2",
+		newPasswordHash, userID,
+	)
+	return err
 }
 
 func (r *Repository) FindAll() ([]User, error) {

--- a/knowledgeable/internal/users/service.go
+++ b/knowledgeable/internal/users/service.go
@@ -11,6 +11,7 @@ type UserRepository interface {
 	FindByUsername(string) (*User, error)
 	FindById(int64) (*User, error)
 	FindAll() ([]User, error)
+	UpdatePassword(int64, string) error
 }
 
 type Service struct {
@@ -95,6 +96,19 @@ func (s *Service) Login(username, password string) (*User, error) {
 	}
 
 	return user, nil
+}
+
+func (s *Service) ChangePassword(userID int64, newPassword string) error {
+	if newPassword == "" {
+		return errors.New("missing password")
+	}
+
+	hashed, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+	if err != nil {
+		return err
+	}
+
+	return s.repo.UpdatePassword(userID, string(hashed))
 }
 
 func (s *Service) GetAll() ([]User, error) {

--- a/knowledgeable/internal/users/service_test.go
+++ b/knowledgeable/internal/users/service_test.go
@@ -31,6 +31,10 @@ func (m *mockRepo) FindById(id int64) (*User, error) {
 	return nil, nil
 }
 
+func (m *mockRepo) UpdatePassword(userID int64, newPasswordHash string) error {
+	return m.err
+}
+
 func (m *mockRepo) FindAll() ([]User, error) {
 	if m.err != nil {
 		return nil, m.err

--- a/knowledgeable/internal/web/router.go
+++ b/knowledgeable/internal/web/router.go
@@ -30,6 +30,7 @@ func SetupRoutes(
 	http.HandleFunc("/login", authHandler.Login)
 	http.HandleFunc("/api/login", authHandler.LoginAPI)
 	http.HandleFunc("/api/me", authHandler.Me)
+	http.HandleFunc("/change-password", authHandler.ChangePassword)
 
 	http.Handle("/metrics", promhttp.Handler())
 

--- a/knowledgeable/templates/change_password.html
+++ b/knowledgeable/templates/change_password.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Change Password</title>
+    <link href="/static/output.css" rel="stylesheet">
+    <link rel="icon" href="/static/favicon.png" />
+</head>
+
+<body class="min-h-screen flex flex-col">
+
+    <div
+        class="relative w-screen h-screen bg-[url('/static/grid-green.svg')] bg-repeat flex items-center justify-center flex-col font-sans tracking-tight">
+        <div
+            class="absolute inset-x-0 bottom-0 top-16 pointer-events-none bg-[radial-gradient(ellipse_80%_80%_at_50%_50%,transparent_30%,#0a0e17_100%)]">
+        </div>
+
+        <div
+            class="w-fit h-fit border border-[#242422] bg-[#090d16] flex flex-col justify-center items-center rounded-lg z-10 p-6 gap-4">
+
+            <form method="POST" action="/change-password" class="flex flex-col gap-5 items-center">
+
+                <div class="flex flex-col w-72">
+                    <h1 class="text-xl font-semibold text-white">Change your password</h1>
+                    <span class="text-gray-400 text-sm">You must set a new password before continuing</span>
+                </div>
+
+                <div class="flex flex-col w-72">
+                    <label for="password" class="text-sm text-gray-400 mb-1">NEW PASSWORD</label>
+                    <input
+                        class="w-72 bg-[#0f172a] border border-gray-800 rounded px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-green-500"
+                        id="password" name="password" type="password" required minlength="8">
+                </div>
+
+                <div class="flex flex-col w-72">
+                    <label for="confirm_password" class="text-sm text-gray-400 mb-1">CONFIRM PASSWORD</label>
+                    <input
+                        class="w-72 bg-[#0f172a] border border-gray-800 rounded px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-green-500"
+                        id="confirm_password" name="confirm_password" type="password" required minlength="8">
+                    <span id="match-error" class="text-red-400 text-xs mt-1 hidden">Passwords do not match</span>
+                </div>
+
+                <button class="w-72 bg-[#1eff8c] hover:bg-[#38be7d] text-black font-bold py-2 rounded transition mt-2" type="submit">
+                    Set new password
+                </button>
+            </form>
+
+        </div>
+
+    </div>
+
+    <script>
+        const form = document.querySelector('form');
+        const pw = document.getElementById('password');
+        const confirm = document.getElementById('confirm_password');
+        const error = document.getElementById('match-error');
+
+        form.addEventListener('submit', (e) => {
+            if (pw.value !== confirm.value) {
+                e.preventDefault();
+                error.classList.remove('hidden');
+            }
+        });
+
+        confirm.addEventListener('input', () => {
+            error.classList.toggle('hidden', pw.value === confirm.value);
+        });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
## What
Added a new change password function after the security leak. A new variable in schema has been added, and sets all users=1, so on their first login, they have to change password

## Why
Becuase of a security leak. We have to tell the users to change passwords

## Related Issue
Closes #

## Type 
- [x] Feature
- [] Bug
- [] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [x] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a password change page where users can securely update their password with validation (minimum 8 characters, confirmation matching).
  * Users flagged to change their password are automatically redirected to the password change page upon login.

* **Tests**
  * Added test coverage for password change functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->