### PR TITLE
fix(cd): added missing working directory to install dependecies step …

### DIFF
--- a/.github/workflows/playwright_staging.yml
+++ b/.github/workflows/playwright_staging.yml
@@ -19,6 +19,7 @@ jobs:
           chmod 600 ~/.ssh/ssh_key
   
       - name: Install dependencies
+        working-directory: knowledgeable
         run: npm ci
 
       - name: Install Playwright browsers


### PR DESCRIPTION


## What
What has been implemented?
added missing working directory to install dependecies step in playwright_staing.yml
## Why
Why is this change needed?
stopped the playwright end2end test for running in staging environment and made the entire pipeline stop.
## Related Issue
Closes #

## Type 
- [] Feature
- [x] Bug
- [] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build workflow configuration for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->