### PR TITLE
fix(cd): added override entrypoint to run migrations with sh

### DIFF
--- a/.github/scripts/deploy-staging.sh
+++ b/.github/scripts/deploy-staging.sh
@@ -28,7 +28,6 @@ docker compose -p staging -f docker-compose-staging.yml --profile tools run --rm
 npx knex migrate:latest &&
 npx knex seed:run --specific=staging_seed.js
 "
-docker compose -p staging -f docker-compose-staging.yml --profile tools rm -f migrations
 echo "[DEPLOY] Start app"
 docker compose -p staging -f docker-compose-staging.yml up -d --remove-orphans app
 echo "[DEPLOY] Checking containers"

--- a/.github/scripts/deploy-staging.sh
+++ b/.github/scripts/deploy-staging.sh
@@ -24,9 +24,9 @@ if [ "$DB_READY" -eq 0 ]; then
   exit 1
 fi
 echo "[DEPLOY] Run migrations + seed"
-docker compose -p staging -f docker-compose-staging.yml --profile tools run migrations sh -c "
-  npx knex migrate:latest &&
-  npx knex seed:run --specific=staging_seed.js
+docker compose -p staging -f docker-compose-staging.yml --profile tools run --rm --entrypoint sh migrations -c "
+npx knex migrate:latest &&
+npx knex seed:run --specific=staging_seed.js
 "
 docker compose -p staging -f docker-compose-staging.yml --profile tools rm -f migrations
 echo "[DEPLOY] Start app"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Staging deployment script updated: migration/seed step now runs through a temporary runtime that is automatically removed and executes via a shell entrypoint; the separate manual container removal step was removed. This yields cleaner container cleanup and more consistent execution during staging deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->