### PR TITLE
Add GitHub Actions workflow for migrations image

### DIFF
--- a/.github/workflows/Build Migrations Image
+++ b/.github/workflows/Build Migrations Image
@@ -1,0 +1,7 @@
+- name: Login to GHCR
+  run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+- name: Build and push migrations image
+  run: |
+    docker build -t ghcr.io/knowledgeables/knowledge-migrations:latest -f Dockerfile.migrations .
+    docker push ghcr.io/knowledgeables/knowledge-migrations:latest


### PR DESCRIPTION
## What
What has been implemented?
Migration workflow that you can manually run when needed.
## Why
Why is this change needed?
Migration image doesn't have the neccessary staging_seed file and therefore the seed can't be run in staging environment.


## Type 
- [] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated Docker image building and publishing for deployments to container registry, improving deployment infrastructure and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->