### PR TITLE
 fix(ci): added workflow to build and push migrations image to GHCR

### DIFF
--- a/.github/workflows/build-and-push-migration.yml
+++ b/.github/workflows/build-and-push-migration.yml
@@ -1,7 +1,11 @@
-name: Build & Push Migrations Image
+name: CI - Build & Push Migrations Image
 
 on:
   workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   build:

--- a/knowledgeable/.dockerignore
+++ b/knowledgeable/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+db-migrations/node_modules


### PR DESCRIPTION
## What
What has been implemented?
Added GitHub Actions workflow to build and push the migrations Docker image to GHCR.
## Why
Why is this change needed?
Staging environment was using an outdated Docker image, causing missing seed files and failed deployments.


## Type 
- [x] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for improved build management.
  * Optimized Docker build context by excluding unnecessary directories from image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->