### PR TITLE
fix(ci): added correct GHCR auth for migrations image push

### DIFF
--- a/.github/workflows/build-and-push-migration.yml
+++ b/.github/workflows/build-and-push-migration.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Login to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
       - name: Build and push migrations image
         run: |

--- a/.github/workflows/build-and-push-migration.yml
+++ b/.github/workflows/build-and-push-migration.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Login to GHCR
-        run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+        run: echo "${{ secrets.CR__PAT }}" | docker login ghcr.io -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
       - name: Build and push migrations image
         run: |


### PR DESCRIPTION
## What
What has been implemented?
Added GitHub Actions workflow to build and push the migrations Docker image using GHCR_TOKEN and DOCKER_USERNAME. Fixed authentication so the migrations image is correctly published.
## Why
Why is this change needed?
Previous setup used GITHUB_TOKEN which lacked permissions to push to GHCR, causing deployment failures due to outdated or missing migrations image.
## Related Issue
Closes #

## Type 
- [] Feature
- [x] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD authentication configuration for container registry operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->