### PR TITLE
fix(ci): added run migrations and seed as seperate steps in staing de…

### DIFF
--- a/.github/scripts/deploy-staging.sh
+++ b/.github/scripts/deploy-staging.sh
@@ -23,11 +23,11 @@ if [ "$DB_READY" -eq 0 ]; then
   echo "[DEPLOY] ERROR: DB never became ready"
   exit 1
 fi
-echo "[DEPLOY] Run migrations + seed"
-docker compose -p staging -f docker-compose-staging.yml --profile tools run --rm --entrypoint sh migrations -c "
-npx knex migrate:latest &&
-npx knex seed:run --specific=staging_seed.js
-"
+echo "[DEPLOY] Run migrations"
+docker compose -p staging -f docker-compose-staging.yml --profile tools run --rm --entrypoint sh migrations -c "npx knex migrate:latest"
+
+echo "[DEPLOY] Run seed"
+docker compose -p staging -f docker-compose-staging.yml --profile tools run --rm --entrypoint sh migrations -c "npx knex seed:run --specific=staging_seed.js"
 echo "[DEPLOY] Start app"
 docker compose -p staging -f docker-compose-staging.yml up -d --remove-orphans app
 echo "[DEPLOY] Checking containers"

--- a/knowledgeable/db-migrations/knexfile.js
+++ b/knowledgeable/db-migrations/knexfile.js
@@ -4,6 +4,7 @@ dotenv.config({});
 /**
  * @type { import("knex").Knex.Config }
  */
+
 export default {
   client: 'postgresql',
   connection: {
@@ -14,5 +15,8 @@ export default {
   },
   migrations: {
     tableName: 'knex_migrations'
+  },
+  seeds: {
+    directory: './seeds'
   }
 };


### PR DESCRIPTION
…ploy

## What
Split knex migrate:latest and knex seed:run into two separate docker compose run calls in the staging deploy script.
## Why
Running both commands in a single sh -c call with && caused the seed to fail with relation "pages" does not exist when the database was fresh, because migrations had not completed successfully before the seed ran.

## Related Issue
Closes #

## Type 
- [] Feature
- [x] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployment process now separates database migration and data seeding into distinct sequential steps for improved operational clarity.
  * Database configuration updated to enable automated discovery and loading of seed data files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->