### PR TITLE
fix(e2e): added baseUrl fixture and baseurl parsing in api fetches as…

### DIFF
--- a/knowledgeable/e2e/full/auth/logout.full.spec.js
+++ b/knowledgeable/e2e/full/auth/logout.full.spec.js
@@ -1,22 +1,33 @@
 import { test, expect } from '@playwright/test';
 
-test("user can log out", async ({ page, request }) => {
+test("user can log out", async ({ page, request, baseURL }) => {
   const username = `test_${Date.now()}`;
   const password = "test123";
 
-  await request.post("/api/register", {
+ 
+  const res = await request.post(`${baseURL}/api/register`, {
     data: { username, email: `${username}@test.com`, password },
   });
 
-  await page.goto("/login");
-  await page.getByLabel("Username").fill(username);
-  await page.getByLabel("Password").fill(password);
-  await page.getByRole("button", { name: /log in/i }).click();
-
-  // logout
-  await page.locator('form[action="/logout"] button').click();
-
-  await page.waitForLoadState("networkidle"); 
+  expect(res.ok()).toBeTruthy(); 
 
 
+  await page.goto('/login');
+  await page.waitForLoadState('networkidle');
+
+  await page.getByRole('textbox', { name: /username/i }).fill(username);
+  await page.getByRole('textbox', { name: /password/i }).fill(password);
+  await page.getByRole('button', { name: /log in/i }).click();
+
+
+  await expect(page.locator('form[action="/logout"] button')).toBeVisible();
+
+ 
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: 'networkidle' }),
+    page.locator('form[action="/logout"] button').click(),
+  ]);
+
+
+  await expect(page).toHaveURL(/login/);
 });

--- a/knowledgeable/e2e/full/auth/register-and-login.full.spec.js
+++ b/knowledgeable/e2e/full/auth/register-and-login.full.spec.js
@@ -1,18 +1,23 @@
 // e2e/full/app.full.spec.js
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test('user can log in (UI)', async ({ page, request }) => {
+test("user can log in", async ({ page, request, baseURL }) => {
   const username = `test_${Date.now()}`;
-  const password = 'test123';
+  const password = "test123";
 
-  await request.post('/api/register', {
+  const registerRes = await request.post(`${baseURL}/api/register`, {
     data: { username, email: `${username}@test.com`, password },
   });
 
-  await page.goto('/login');
-  await page.getByLabel('Username').fill(username);
-  await page.getByLabel('Password').fill(password);
-  await page.getByRole('button', { name: 'Log in' }).click();
+  expect(registerRes.ok()).toBeTruthy();
 
-  await expect(page).toHaveURL('/');
+  await page.goto("/login");
+  await page.getByLabel("Username").fill(username);
+  await page.getByLabel("Password").fill(password);
+  await page.getByRole("button", { name: /log in/i }).click();
+
+  await expect(page).toHaveURL(/\/$/);
+
+  const meRes = await page.request.get("/api/me");
+  expect(meRes.status()).toBe(200);
 });

--- a/knowledgeable/e2e/full/template/template-criterias.full.spec.js
+++ b/knowledgeable/e2e/full/template/template-criterias.full.spec.js
@@ -41,14 +41,16 @@ import { test, expect } from "@playwright/test";
   });
 
 
-test("authenticated user sees user-navbar", async ({ page, request }) => {
+test("authenticated user sees user-navbar", async ({ page, request, baseURL }) => {
   const username = `test_${Date.now()}`;
   const password = "test123";
 
   // register
-  await request.post("/api/register", {
-    data: { username, email: `${username}@test.com`, password },
-  });
+ const res = await request.post(`${baseURL}/api/register`, {
+  data: { username, email: `${username}@test.com`, password },
+});
+
+expect(res.ok()).toBeTruthy();
 
   // login via UI
   await page.goto("/login");
@@ -56,7 +58,7 @@ test("authenticated user sees user-navbar", async ({ page, request }) => {
   await page.getByLabel("Password").fill(password);
   await page.getByRole("button", { name: /log in/i }).click();
 
-  await expect(page).toHaveURL("/");
+  await expect(page).toHaveURL(/\/$/);
 
   // assertions
   await expect(page.getByText(username)).toBeVisible();


### PR DESCRIPTION


## What
What has been implemented?
added baseUrl fixture and baseurl parsing in api fetches 
## Why
the tests needs the staging baseUrl in order to pass. 


## Type 
- [] Feature
- [x] Bug
- [] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test coverage for authentication flows (login, logout, registration) and template functionality with enhanced assertions and more reliable navigation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->