### PR TITLE
fix(backend): changed cooking secure configuration

### DIFF
--- a/knowledgeable/internal/auth/handler.go
+++ b/knowledgeable/internal/auth/handler.go
@@ -154,7 +154,7 @@ func (h *Handler) LoginAPI(w http.ResponseWriter, r *http.Request) {
 		SameSite: http.SameSiteLaxMode,
 		HttpOnly: true,
 		Path:     "/",
-		Secure:   os.Getenv("APP_ENV") != "dev",
+		Secure: os.Getenv("APP_ENV") == "production",
 	})
 
 	if user.ShouldChangePassword {


### PR DESCRIPTION


## What
What has been implemented?
Changed the secure cookie configuration in auth.handler. to only be secure when the environment is set as "production"
## Why
Why is this change needed?
When running playwright tests aimed towards userflow, the secure cookie tag that targeted everything that's not "dev" environment. this meant that the playwright tests could not establish sessions, because staging server sends http. Therefore making two auth tests fail.

## Type 
- [] Feature
- [x] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session security by refining how session cookies are transmitted across different environments, ensuring stricter security standards in production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->