### PR TITLE
fix(healthcheck): changed the healthcheck from wget to rely on server…

### DIFF
--- a/knowledgeable/cmd/server/main.go
+++ b/knowledgeable/cmd/server/main.go
@@ -20,6 +20,18 @@ import (
 
 func main() {
 
+	if len(os.Args) > 1 && os.Args[1] == "healthcheck" {
+        resp, err := http.Get("http://localhost:8080/health")
+        if err != nil {
+            os.Exit(1)
+        }
+        defer resp.Body.Close()
+        if resp.StatusCode != http.StatusOK {
+            os.Exit(1)
+        }
+        os.Exit(0)
+    }
+
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
 	log.Println("[APP] Starting application")
 

--- a/knowledgeable/cmd/server/main.go
+++ b/knowledgeable/cmd/server/main.go
@@ -21,16 +21,16 @@ import (
 func main() {
 
 	if len(os.Args) > 1 && os.Args[1] == "healthcheck" {
-        resp, err := http.Get("http://localhost:8080/health")
-        if err != nil {
-            os.Exit(1)
-        }
-        defer resp.Body.Close()
-        if resp.StatusCode != http.StatusOK {
-            os.Exit(1)
-        }
-        os.Exit(0)
-    }
+    resp, err := http.Get("http://localhost:8080/health")
+		if err != nil {
+			os.Exit(1)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			os.Exit(1)
+		}
+    os.Exit(0)
+}
 
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
 	log.Println("[APP] Starting application")

--- a/knowledgeable/docker-compose-prod.yml
+++ b/knowledgeable/docker-compose-prod.yml
@@ -44,7 +44,7 @@ services:
     networks:
       - knowledgeable_network
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health"]
+      test: ["CMD", "/app/server", "healthcheck"]
       interval: 10s
       timeout: 3s
       retries: 5

--- a/knowledgeable/go.mod
+++ b/knowledgeable/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require golang.org/x/crypto v0.48.0
 
 require (
+	github.com/lib/pq v1.12.3
 	github.com/prometheus/client_golang v1.23.2
 	github.com/swaggo/http-swagger v1.3.4
 	github.com/swaggo/swag v1.16.6
@@ -22,7 +23,6 @@ require (
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/lib/pq v1.12.3 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect


### PR DESCRIPTION
… in main

## What
prior healtheck was on wget in docker dockerimage. however the distroless image doesnt carry wget, so we use health checks from the main.go

## Why
for the app to be declared healrhy

## Related Issue
Closes #

## Type 
- [] Feature
- [x] Bug
- [] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a lightweight health-check command to verify the app is healthy without performing full startup.
  * Updated production container configuration to use the new internal health-check mechanism.
  * Pinned/adjusted a database driver dependency to stabilize builds and deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->