### PR TITLE
fix(nginx): removed unused nginx folder and added new one for scp

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -66,5 +66,6 @@ jobs:
             cd ~/app
             docker compose pull
             docker compose up -d --remove-orphans
+            docker compose up -d --no-deps --force-recreate nginx
             docker compose ps
           EOF

--- a/knowledgeable/docker-compose-build.yml
+++ b/knowledgeable/docker-compose-build.yml
@@ -10,9 +10,3 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.migrations
-
-  nginx:
-    image: ghcr.io/knowledgeables/knowledge_nginx:${IMAGE_TAG:-latest}
-    build:
-      context: ./network
-      dockerfile: Dockerfile

--- a/knowledgeable/network/Dockerfile
+++ b/knowledgeable/network/Dockerfile
@@ -1,3 +1,0 @@
-FROM nginx:alpine
-
-COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/knowledgeable/nginx/secure/default.conf.template
+++ b/knowledgeable/nginx/secure/default.conf.template
@@ -2,18 +2,19 @@ server {
     listen 80;
     server_name ${APP_DOMAIN};
 
-    location / {
-        return 301 https://$host$request_uri;
-    }
-
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
     }
 }
 
 server {
     listen 443 ssl;
     server_name ${APP_DOMAIN};
+
     server_tokens off;
     client_max_body_size 20M;
 
@@ -22,12 +23,16 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
+    resolver 127.0.0.11 valid=10s;
+
     location / {
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header X-Url-Scheme $scheme;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $http_host;
-        proxy_redirect off;
         proxy_pass http://app:8080;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_redirect off;
     }
 }


### PR DESCRIPTION
## What
removed the unused custom nginx image and added a new nginx.conf file, which will be directly scp´ed over to the vm

## Why
so the repo and vm conf file are the same

## Related Issue
Closes #

## Type 
- [] Feature
- [x] Bug
- [] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment process for service restart behavior with improved isolation.
  * Modified reverse proxy configuration to enhance request routing and DNS resolution.
  * Streamlined service deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->