### PR TITLE
fix(logging): added filter for non-pageview traffic and imporved trac…

### DIFF
--- a/knowledgeable/internal/middleware/tracking.go
+++ b/knowledgeable/internal/middleware/tracking.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,6 +23,13 @@ const cookieName = "tracking_id"
 // It also injects tracking id in the request context
 func Tracking(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if !shouldTrack(r) {
+			ctx := context.WithValue(r.Context(), sessionKey, "")
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
+		}
+
 		var trackingID string
 
 		// attempts to collect the already existd ing cookie
@@ -82,9 +90,16 @@ func PageView(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		wrapped := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+
 		next.ServeHTTP(wrapped, r)
+
+		if !isPageview(r, wrapped.statusCode) {
+			return
+		}
+
 		duration := time.Since(start)
-		slog.Info("pageview", // #nosec G706 -- JSON handler escapes all values
+
+		slog.Info("pageview",
 			"event", "pageview",
 			"tracking_id", GetTrackingID(r),
 			"path", r.URL.Path,
@@ -93,6 +108,42 @@ func PageView(next http.Handler) http.Handler {
 			"duration_ms", duration.Milliseconds(),
 		)
 	})
+}
+func isPageview(r *http.Request, status int) bool {
+	path := r.URL.Path
+
+	if path == "/health" {
+		return false
+	}
+
+	if strings.HasPrefix(path, "/static/") {
+		return false
+	}
+
+	// only GET methods count as page view
+	if r.Method != http.MethodGet {
+		return false
+	}
+
+	if status >= 300 {
+		return false
+	}
+
+	return true
+}
+
+func shouldTrack(r *http.Request) bool {
+	path := r.URL.Path
+
+	if path == "/health" {
+		return false
+	}
+	
+	if strings.HasPrefix(path, "/static/") {
+		return false
+	}
+
+	return true
 }
 
 type responseWriter struct {


### PR DESCRIPTION
## What
Cleaned up the logging middleware.

- Removed /health and /static from logs
- No longer logs redirects as pageviews
- Only logs GET requests as pageviews
- Ensures tracking_id is always set (even for requests we don’t track)


## Why
Logs were full of noise (health checks, static files), making it hard to see actual traffic.

Also tracking_id was sometimes missing, which caused inconsistent logs.

## Type 
- [ ] Feature
- [x] Bug
- [ ] Chore
- [ ] Docs

## Definition of Done
- [x] Code implemented
- [ ] Tests added (if relevant)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking accuracy by excluding health checks and static assets from page view logging and analytics collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->