### PR TITLE
fix(delivery): added pushing latest docker image tag in delivery work…

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -29,8 +29,12 @@ jobs:
       - name: Log in to GHCR
         run: echo "${{ secrets.CR__PAT }}" | docker login ghcr.io -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
-      - name: Build and push all images
+      - name: Build and push all images (sha tag)
         working-directory: knowledgeable
         env:
           IMAGE_TAG: ${{ github.sha }}
+        run: docker buildx bake -f docker-compose-build.yml --push
+
+      - name: Build and push all images (latest tag)
+        working-directory: knowledgeable
         run: docker buildx bake -f docker-compose-build.yml --push


### PR DESCRIPTION
…flow so staging always runs the current build

## What
What has been implemented?

## Why
Why is this change needed?

## Related Issue
Closes #

## Type 
- [] Feature
- [] Bug
- [] Chore
- [] Docs

## Definition of Done
- [] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image delivery workflow to generate both commit SHA and latest tags during deployment, improving deployment flexibility and version tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->