### PR TITLE
Feat/forgot password integration

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(xargs wc *)",
-      "Bash(go build *)"
+      "Bash(go build *)",
+      "Bash(grep -E \"\\(\\\\.go|\\\\.sql|\\\\.env|\\\\.yaml|\\\\.yml\\)$\")"
     ]
   }
 }

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -44,14 +44,19 @@ jobs:
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           CRAWLER_KEY: ${{ secrets.CRAWLER_KEY }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          FROM_EMAIL: ${{ secrets.FROM_EMAIL }}
         run: |
           umask 077
-          printf 'IMAGE_TAG=%s\n'         "$IMAGE_TAG"         >  .env
-          printf 'APP_DOMAIN=%s\n'        "$APP_DOMAIN"        >> .env
-          printf 'POSTGRES_USER=%s\n'     "$POSTGRES_USER"     >> .env
-          printf 'POSTGRES_PASSWORD=%s\n' "$POSTGRES_PASSWORD" >> .env
-          printf 'DATABASE_URL=%s\n'      "$DATABASE_URL"      >> .env
-          printf 'CRAWLER_KEY=%s\n'       "$CRAWLER_KEY"       >> .env
+          printf 'IMAGE_TAG=%s\n'         "$IMAGE_TAG"           >  .env
+          printf 'APP_DOMAIN=%s\n'        "$APP_DOMAIN"          >> .env
+          printf 'POSTGRES_USER=%s\n'     "$POSTGRES_USER"       >> .env
+          printf 'POSTGRES_PASSWORD=%s\n' "$POSTGRES_PASSWORD"   >> .env
+          printf 'DATABASE_URL=%s\n'      "$DATABASE_URL"        >> .env
+          printf 'CRAWLER_KEY=%s\n'       "$CRAWLER_KEY"         >> .env
+          printf 'RESEND_API_KEY=%s\n'    "$RESEND_API_KEY"      >> .env
+          printf 'FROM_EMAIL=%s\n'        "$FROM_EMAIL"          >> .env
+          printf 'APP_BASE_URL=https://%s\n' "$APP_DOMAIN"       >> .env
 
       - name: Transfer .env to server
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ tmp/
 
 # Tailwind output
 static/output.css
+
+# Claude Code
+.claude/

--- a/knowledgeable/.gitignore
+++ b/knowledgeable/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 /playwright/.cache/
 /playwright/.auth/
 static/output.css
+.claude

--- a/knowledgeable/cmd/server/main.go
+++ b/knowledgeable/cmd/server/main.go
@@ -6,6 +6,7 @@ import (
 	_ "knowledgeable/docs"
 	"knowledgeable/internal/auth"
 	"knowledgeable/internal/db"
+	"knowledgeable/internal/email"
 	"knowledgeable/internal/middleware"
 	"knowledgeable/internal/pages"
 	"knowledgeable/internal/users"
@@ -71,7 +72,11 @@ func main() {
 	pageHandler := pages.NewHandler(pageService, tmplLoader)
 
 	// auth
-	authHandler := auth.NewHandler(userService, tmplLoader)
+	emailSender := email.NewResendSender(
+		os.Getenv("RESEND_API_KEY"),
+		os.Getenv("FROM_EMAIL"),
+	)
+	authHandler := auth.NewHandler(userService, tmplLoader, emailSender, os.Getenv("APP_BASE_URL"))
 
 	// routes
 	web.SetupRoutes(

--- a/knowledgeable/db-migrations/migrations/20260426000000_add_password_reset_tokens.js
+++ b/knowledgeable/db-migrations/migrations/20260426000000_add_password_reset_tokens.js
@@ -1,0 +1,17 @@
+export async function up(knex) {
+  await knex.schema.createTable('password_reset_tokens', (table) => {
+    table.increments('id').primary();
+    table.integer('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.text('token_hash').notNullable().unique();
+    table.timestamp('expires_at', { useTz: true }).notNullable();
+    table.timestamp('used_at', { useTz: true });
+    table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+  });
+
+  await knex.schema.raw('CREATE INDEX idx_password_reset_tokens_hash ON password_reset_tokens(token_hash)');
+  await knex.schema.raw('CREATE INDEX idx_password_reset_tokens_user ON password_reset_tokens(user_id)');
+}
+
+export async function down(knex) {
+  await knex.schema.dropTableIfExists('password_reset_tokens');
+}

--- a/knowledgeable/docker-compose-dev.yml
+++ b/knowledgeable/docker-compose-dev.yml
@@ -26,6 +26,9 @@ services:
     environment:
       APP_ENV: dev
       DATABASE_URL: ${DATABASE_URL:-postgres://postgres:postgres@db:5432/knowledge?sslmode=disable}
+      RESEND_API_KEY: ${RESEND_API_KEY}
+      FROM_EMAIL: ${FROM_EMAIL}
+      APP_BASE_URL: ${APP_BASE_URL}
     depends_on:
       - db
   migrations:

--- a/knowledgeable/docker-compose-prod.yml
+++ b/knowledgeable/docker-compose-prod.yml
@@ -39,7 +39,7 @@ services:
       CRAWLER_KEY: ${CRAWLER_KEY:?CRAWLER_KEY is required}
       RESEND_API_KEY: ${RESEND_API_KEY:?RESEND_API_KEY is required}
       FROM_EMAIL: ${FROM_EMAIL:?FROM_EMAIL is required}
-      APP_BASE_URL: ${APP_BASE_URL}
+      APP_BASE_URL: ${APP_BASE_URL:?APP_BASE_URL is required}
     depends_on:
       db:
         condition: service_healthy

--- a/knowledgeable/docker-compose-prod.yml
+++ b/knowledgeable/docker-compose-prod.yml
@@ -37,6 +37,9 @@ services:
       APP_ENV: production
       DATABASE_URL: ${DATABASE_URL:?DATABASE_URL is required}
       CRAWLER_KEY: ${CRAWLER_KEY:?CRAWLER_KEY is required}
+      RESEND_API_KEY: ${RESEND_API_KEY:?RESEND_API_KEY is required}
+      FROM_EMAIL: ${FROM_EMAIL:?FROM_EMAIL is required}
+      APP_BASE_URL: ${APP_BASE_URL}
     depends_on:
       db:
         condition: service_healthy

--- a/knowledgeable/internal/auth/auth_integration_test.go
+++ b/knowledgeable/internal/auth/auth_integration_test.go
@@ -28,13 +28,25 @@ func (s *successUserService) ChangePassword(userID int64, newPassword string) er
 	return nil
 }
 
+func (s *successUserService) GetByEmail(email string) (*users.User, error) {
+	return &users.User{ID: 1, Email: email}, nil
+}
+
+func (s *successUserService) CreateResetToken(userID int64) (string, error) {
+	return "token", nil
+}
+
+func (s *successUserService) ConsumeResetToken(rawToken string) (int64, error) {
+	return 1, nil
+}
+
 // HAPPY PATH
 func TestLoginAPI_SetsSessionCookie(t *testing.T) {
 
 	userService := &successUserService{}
 	handler := NewHandler(userService, func() *template.Template {
 		return template.New("dummy")
-	})
+	}, nil, "")
 
 	sessions = map[string]int64{}
 
@@ -107,12 +119,34 @@ func (s *failUserService) ChangePassword(userID int64, newPassword string) error
 	return errors.New("change password failed")
 }
 
+func (s *failUserService) GetByEmail(email string) (*users.User, error) {
+	return nil, errors.New("user not found")
+}
+
+func (s *failUserService) CreateResetToken(userID int64) (string, error) {
+	return "", errors.New("failed")
+}
+
+func (s *failUserService) ConsumeResetToken(rawToken string) (int64, error) {
+	return 0, errors.New("invalid token")
+}
+
+type mockEmailSender struct {
+	sentTo  string
+	err     error
+}
+
+func (m *mockEmailSender) Send(to, subject, html string) error {
+	m.sentTo = to
+	return m.err
+}
+
 func TestLoginAPI_InvalidCredentials(t *testing.T) {
 
 	userService := &failUserService{}
 	handler := NewHandler(userService, func() *template.Template {
 		return template.New("dummy")
-	})
+	}, nil, "")
 
 	sessions = map[string]int64{}
 
@@ -150,5 +184,155 @@ func TestLoginAPI_InvalidCredentials(t *testing.T) {
 	// ingen session
 	if len(sessions) != 0 {
 		t.Fatal("expected no session to be created")
+	}
+}
+
+// ForgotPassword
+
+func TestForgotPassword_UnknownEmail_RedirectsToSent(t *testing.T) {
+	handler := NewHandler(&failUserService{}, func() *template.Template {
+		return template.New("dummy")
+	}, nil, "")
+
+	form := url.Values{}
+	form.Add("email", "unknown@test.com")
+
+	req := httptest.NewRequest(http.MethodPost, "/forgot-password", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rr := httptest.NewRecorder()
+	handler.ForgotPassword(rr, req)
+	res := rr.Result()
+
+	if res.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", res.StatusCode)
+	}
+	if res.Header.Get("Location") != "/forgot-password?sent=1" {
+		t.Fatalf("expected redirect to ?sent=1, got %s", res.Header.Get("Location"))
+	}
+}
+
+func TestForgotPassword_KnownUser_SendsEmailAndRedirects(t *testing.T) {
+	sender := &mockEmailSender{}
+	handler := NewHandler(&successUserService{}, func() *template.Template {
+		return template.New("dummy")
+	}, sender, "http://localhost:8080")
+
+	form := url.Values{}
+	form.Add("email", "rasmus@test.com")
+
+	req := httptest.NewRequest(http.MethodPost, "/forgot-password", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rr := httptest.NewRecorder()
+	handler.ForgotPassword(rr, req)
+	res := rr.Result()
+
+	if res.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", res.StatusCode)
+	}
+	if res.Header.Get("Location") != "/forgot-password?sent=1" {
+		t.Fatalf("expected redirect to ?sent=1, got %s", res.Header.Get("Location"))
+	}
+	if sender.sentTo != "rasmus@test.com" {
+		t.Fatalf("expected email sent to rasmus@test.com, got %q", sender.sentTo)
+	}
+}
+
+func TestForgotPassword_MissingEmail_RedirectsWithError(t *testing.T) {
+	handler := NewHandler(&successUserService{}, func() *template.Template {
+		return template.New("dummy")
+	}, nil, "")
+
+	form := url.Values{}
+	form.Add("email", "")
+
+	req := httptest.NewRequest(http.MethodPost, "/forgot-password", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rr := httptest.NewRecorder()
+	handler.ForgotPassword(rr, req)
+	res := rr.Result()
+
+	if res.Header.Get("Location") != "/forgot-password?error=missing_email" {
+		t.Fatalf("expected missing_email redirect, got %s", res.Header.Get("Location"))
+	}
+}
+
+// ResetPassword
+
+func TestResetPassword_POST_Success(t *testing.T) {
+	handler := NewHandler(&successUserService{}, func() *template.Template {
+		return template.New("dummy")
+	}, nil, "")
+
+	form := url.Values{}
+	form.Add("token", "validtoken")
+	form.Add("password", "newpassword1")
+	form.Add("confirm_password", "newpassword1")
+
+	req := httptest.NewRequest(http.MethodPost, "/reset-password", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rr := httptest.NewRecorder()
+	handler.ResetPassword(rr, req)
+	res := rr.Result()
+
+	if res.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", res.StatusCode)
+	}
+	if res.Header.Get("Location") != "/login?reset=1" {
+		t.Fatalf("expected redirect to /login?reset=1, got %s", res.Header.Get("Location"))
+	}
+}
+
+func TestResetPassword_POST_PasswordMismatch_Redirects(t *testing.T) {
+	handler := NewHandler(&successUserService{}, func() *template.Template {
+		return template.New("dummy")
+	}, nil, "")
+
+	form := url.Values{}
+	form.Add("token", "sometoken")
+	form.Add("password", "password1")
+	form.Add("confirm_password", "password2")
+
+	req := httptest.NewRequest(http.MethodPost, "/reset-password", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rr := httptest.NewRecorder()
+	handler.ResetPassword(rr, req)
+	res := rr.Result()
+
+	if res.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", res.StatusCode)
+	}
+	location := res.Header.Get("Location")
+	if !strings.Contains(location, "error=passwords_mismatch") {
+		t.Fatalf("expected passwords_mismatch error, got %s", location)
+	}
+}
+
+func TestResetPassword_POST_InvalidToken_RedirectsToForgot(t *testing.T) {
+	handler := NewHandler(&failUserService{}, func() *template.Template {
+		return template.New("dummy")
+	}, nil, "")
+
+	form := url.Values{}
+	form.Add("token", "expiredtoken")
+	form.Add("password", "newpassword1")
+	form.Add("confirm_password", "newpassword1")
+
+	req := httptest.NewRequest(http.MethodPost, "/reset-password", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rr := httptest.NewRecorder()
+	handler.ResetPassword(rr, req)
+	res := rr.Result()
+
+	if res.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", res.StatusCode)
+	}
+	if res.Header.Get("Location") != "/forgot-password?error=invalid_token" {
+		t.Fatalf("expected redirect to /forgot-password?error=invalid_token, got %s", res.Header.Get("Location"))
 	}
 }

--- a/knowledgeable/internal/auth/handler.go
+++ b/knowledgeable/internal/auth/handler.go
@@ -6,11 +6,13 @@ import (
 	"html/template"
 	"knowledgeable/internal/middleware"
 	"knowledgeable/internal/observability"
+	"knowledgeable/internal/ratelimit"
 	"knowledgeable/internal/users"
 	"log/slog"
 	"net/http"
 	"os"
 	"strings"
+	"time"
 )
 
 type LoginRequest struct {
@@ -42,10 +44,12 @@ type EmailSender interface {
 }
 
 type Handler struct {
-	userService UserService
-	loadTmpl    func() *template.Template
-	emailSender EmailSender
-	baseURL     string
+	userService    UserService
+	loadTmpl       func() *template.Template
+	emailSender    EmailSender
+	baseURL        string
+	forgotLimiter  *ratelimit.IPLimiter
+	resetLimiter   *ratelimit.IPLimiter
 }
 
 type LoginPageData struct {
@@ -64,10 +68,12 @@ type ResetPasswordPageData struct {
 
 func NewHandler(us UserService, load func() *template.Template, emailSender EmailSender, baseURL string) *Handler {
 	return &Handler{
-		userService: us,
-		loadTmpl:    load,
-		emailSender: emailSender,
-		baseURL:     baseURL,
+		userService:   us,
+		loadTmpl:      load,
+		emailSender:   emailSender,
+		baseURL:       baseURL,
+		forgotLimiter: ratelimit.NewIPLimiter(5, 15*time.Minute),
+		resetLimiter:  ratelimit.NewIPLimiter(10, 15*time.Minute),
 	}
 }
 
@@ -394,6 +400,16 @@ func (h *Handler) ForgotPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ip := ratelimit.RealIP(r)
+
+	if !h.forgotLimiter.Allow(ip) {
+		slog.Warn("forgot_password_rate_limited",
+			observability.LogAttrs("auth.forgot_password", trackingID, nil, "ip", ip)...,
+		)
+		http.Error(w, "too many requests", http.StatusTooManyRequests)
+		return
+	}
+
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
@@ -405,11 +421,16 @@ func (h *Handler) ForgotPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	emailDomain := emailDomainOf(emailAddr)
+
+	slog.Info("forgot_password_requested",
+		observability.LogAttrs("auth.forgot_password", trackingID, nil, "email_domain", emailDomain, "ip", ip)...,
+	)
+
 	user, err := h.userService.GetByEmail(emailAddr)
 	if err != nil || user == nil {
-		// Don't reveal whether the email exists
 		slog.Info("forgot_password_unknown_email",
-			observability.LogAttrs("auth.forgot_password", trackingID, nil, "email", emailAddr)...,
+			observability.LogAttrs("auth.forgot_password", trackingID, nil, "email_domain", emailDomain)...,
 		)
 		http.Redirect(w, r, "/forgot-password?sent=1", http.StatusSeeOther)
 		return
@@ -420,7 +441,7 @@ func (h *Handler) ForgotPassword(w http.ResponseWriter, r *http.Request) {
 		slog.Error("forgot_password_token_failed",
 			observability.LogAttrs("auth.forgot_password", trackingID, &user.ID, "error", err.Error())...,
 		)
-		http.Error(w, "internal error", http.StatusInternalServerError)
+		http.Redirect(w, r, "/forgot-password?sent=1", http.StatusSeeOther)
 		return
 	}
 
@@ -434,12 +455,12 @@ func (h *Handler) ForgotPassword(w http.ResponseWriter, r *http.Request) {
 		slog.Error("forgot_password_email_failed",
 			observability.LogAttrs("auth.forgot_password", trackingID, &user.ID, "error", err.Error())...,
 		)
-		http.Error(w, "internal error", http.StatusInternalServerError)
+		http.Redirect(w, r, "/forgot-password?sent=1", http.StatusSeeOther)
 		return
 	}
 
 	slog.Info("forgot_password_sent",
-		observability.LogAttrs("auth.forgot_password", trackingID, &user.ID)...,
+		observability.LogAttrs("auth.forgot_password", trackingID, &user.ID, "email_domain", emailDomain)...,
 	)
 
 	http.Redirect(w, r, "/forgot-password?sent=1", http.StatusSeeOther)
@@ -479,6 +500,16 @@ func (h *Handler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ip := ratelimit.RealIP(r)
+
+	if !h.resetLimiter.Allow(ip) {
+		slog.Warn("reset_password_rate_limited",
+			observability.LogAttrs("auth.reset_password", trackingID, nil, "ip", ip)...,
+		)
+		http.Error(w, "too many requests", http.StatusTooManyRequests)
+		return
+	}
+
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
@@ -494,9 +525,16 @@ func (h *Handler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if password != confirm {
+		slog.Debug("reset_password_mismatch",
+			observability.LogAttrs("auth.reset_password", trackingID, nil)...,
+		)
 		http.Redirect(w, r, "/reset-password?token="+token+"&error=passwords_mismatch", http.StatusSeeOther)
 		return
 	}
+
+	slog.Info("reset_password_attempted",
+		observability.LogAttrs("auth.reset_password", trackingID, nil)...,
+	)
 
 	userID, err := h.userService.ConsumeResetToken(token)
 	if err != nil {
@@ -520,4 +558,11 @@ func (h *Handler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 	)
 
 	http.Redirect(w, r, "/login?reset=1", http.StatusSeeOther)
+}
+
+func emailDomainOf(email string) string {
+	if i := strings.LastIndex(email, "@"); i >= 0 {
+		return email[i+1:]
+	}
+	return "unknown"
 }

--- a/knowledgeable/internal/auth/handler.go
+++ b/knowledgeable/internal/auth/handler.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/json"
+	"fmt"
 	"html/template"
 	"knowledgeable/internal/middleware"
 	"knowledgeable/internal/observability"
@@ -31,21 +32,42 @@ type UserService interface {
 	Login(string, string) (*users.User, error)
 	GetByID(id int64) (*users.User, error)
 	ChangePassword(userID int64, newPassword string) error
+	GetByEmail(email string) (*users.User, error)
+	CreateResetToken(userID int64) (string, error)
+	ConsumeResetToken(rawToken string) (int64, error)
+}
+
+type EmailSender interface {
+	Send(to, subject, html string) error
 }
 
 type Handler struct {
 	userService UserService
 	loadTmpl    func() *template.Template
+	emailSender EmailSender
+	baseURL     string
 }
 
 type LoginPageData struct {
 	Error string
 }
 
-func NewHandler(us UserService, load func() *template.Template) *Handler {
+type ForgotPasswordPageData struct {
+	Sent  bool
+	Error string
+}
+
+type ResetPasswordPageData struct {
+	Token string
+	Error string
+}
+
+func NewHandler(us UserService, load func() *template.Template, emailSender EmailSender, baseURL string) *Handler {
 	return &Handler{
 		userService: us,
 		loadTmpl:    load,
+		emailSender: emailSender,
+		baseURL:     baseURL,
 	}
 }
 
@@ -335,4 +357,167 @@ func (h *Handler) Me(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
+}
+
+// ForgotPassword godoc
+// @Summary Request password reset
+// @Description Sends a password reset email if the address is registered
+// @Tags auth
+// @Accept application/x-www-form-urlencoded
+// @Produce html
+// @Param email formData string true "Email address"
+// @Success 303 {string} string "Redirect to /forgot-password?sent=1"
+// @Router /forgot-password [get,post]
+func (h *Handler) ForgotPassword(w http.ResponseWriter, r *http.Request) {
+	trackingID := middleware.GetTrackingID(r)
+
+	if r.Method == http.MethodGet {
+		tmpl := h.loadTmpl()
+		data := ForgotPasswordPageData{}
+		switch r.URL.Query().Get("error") {
+		case "missing_email":
+			data.Error = "Please enter an email address"
+		case "invalid_token":
+			data.Error = "This reset link is invalid or has expired"
+		}
+		if r.URL.Query().Get("sent") == "1" {
+			data.Sent = true
+		}
+		if err := tmpl.ExecuteTemplate(w, "forgot_password.html", data); err != nil {
+			http.Error(w, "template error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	emailAddr := strings.TrimSpace(r.FormValue("email"))
+	if emailAddr == "" {
+		http.Redirect(w, r, "/forgot-password?error=missing_email", http.StatusSeeOther)
+		return
+	}
+
+	user, err := h.userService.GetByEmail(emailAddr)
+	if err != nil || user == nil {
+		// Don't reveal whether the email exists
+		slog.Info("forgot_password_unknown_email",
+			observability.LogAttrs("auth.forgot_password", trackingID, nil, "email", emailAddr)...,
+		)
+		http.Redirect(w, r, "/forgot-password?sent=1", http.StatusSeeOther)
+		return
+	}
+
+	rawToken, err := h.userService.CreateResetToken(user.ID)
+	if err != nil {
+		slog.Error("forgot_password_token_failed",
+			observability.LogAttrs("auth.forgot_password", trackingID, &user.ID, "error", err.Error())...,
+		)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	resetURL := fmt.Sprintf("%s/reset-password?token=%s", h.baseURL, rawToken)
+	html := fmt.Sprintf(
+		`<p>Click <a href="%s">here</a> to reset your password. This link expires in 1 hour.</p>`,
+		resetURL,
+	)
+
+	if err := h.emailSender.Send(user.Email, "Reset your password", html); err != nil {
+		slog.Error("forgot_password_email_failed",
+			observability.LogAttrs("auth.forgot_password", trackingID, &user.ID, "error", err.Error())...,
+		)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Info("forgot_password_sent",
+		observability.LogAttrs("auth.forgot_password", trackingID, &user.ID)...,
+	)
+
+	http.Redirect(w, r, "/forgot-password?sent=1", http.StatusSeeOther)
+}
+
+// ResetPassword godoc
+// @Summary Reset password via token
+// @Description Validates the reset token and updates the user's password
+// @Tags auth
+// @Accept application/x-www-form-urlencoded
+// @Produce html
+// @Param token query string true "Reset token"
+// @Success 303 {string} string "Redirect to /login"
+// @Router /reset-password [get,post]
+func (h *Handler) ResetPassword(w http.ResponseWriter, r *http.Request) {
+	trackingID := middleware.GetTrackingID(r)
+
+	if r.Method == http.MethodGet {
+		token := r.URL.Query().Get("token")
+		if token == "" {
+			http.Redirect(w, r, "/forgot-password", http.StatusSeeOther)
+			return
+		}
+		tmpl := h.loadTmpl()
+		data := ResetPasswordPageData{Token: token}
+		if r.URL.Query().Get("error") == "passwords_mismatch" {
+			data.Error = "Passwords do not match"
+		}
+		if err := tmpl.ExecuteTemplate(w, "reset_password.html", data); err != nil {
+			http.Error(w, "template error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	token := strings.TrimSpace(r.FormValue("token"))
+	password := strings.TrimSpace(r.FormValue("password"))
+	confirm := strings.TrimSpace(r.FormValue("confirm_password"))
+
+	if token == "" || password == "" || confirm == "" {
+		http.Error(w, "missing fields", http.StatusBadRequest)
+		return
+	}
+
+	if password != confirm {
+		http.Redirect(w, r, "/reset-password?token="+token+"&error=passwords_mismatch", http.StatusSeeOther)
+		return
+	}
+
+	userID, err := h.userService.ConsumeResetToken(token)
+	if err != nil {
+		slog.Warn("reset_password_invalid_token",
+			observability.LogAttrs("auth.reset_password", trackingID, nil, "error", err.Error())...,
+		)
+		http.Redirect(w, r, "/forgot-password?error=invalid_token", http.StatusSeeOther)
+		return
+	}
+
+	if err := h.userService.ChangePassword(userID, password); err != nil {
+		slog.Error("reset_password_change_failed",
+			observability.LogAttrs("auth.reset_password", trackingID, &userID, "error", err.Error())...,
+		)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	slog.Info("reset_password_success",
+		observability.LogAttrs("auth.reset_password", trackingID, &userID)...,
+	)
+
+	http.Redirect(w, r, "/login?reset=1", http.StatusSeeOther)
 }

--- a/knowledgeable/internal/email/sender.go
+++ b/knowledgeable/internal/email/sender.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"time"
 )
 
 type Sender interface {
@@ -23,7 +24,7 @@ func NewResendSender(apiKey, fromAddr string) *ResendSender {
 	return &ResendSender{
 		apiKey:   apiKey,
 		fromAddr: fromAddr,
-		client:   &http.Client{},
+		client:   &http.Client{Timeout: 10 * time.Second},
 	}
 }
 
@@ -39,7 +40,6 @@ func (r *ResendSender) Send(to, subject, html string) error {
 		slog.Info("email (dev mode — no RESEND_API_KEY set)",
 			"to", to,
 			"subject", subject,
-			"body", html,
 		)
 		return nil
 	}
@@ -65,7 +65,7 @@ func (r *ResendSender) Send(to, subject, html string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(resp.Body)

--- a/knowledgeable/internal/email/sender.go
+++ b/knowledgeable/internal/email/sender.go
@@ -1,0 +1,76 @@
+package email
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+)
+
+type Sender interface {
+	Send(to, subject, html string) error
+}
+
+type ResendSender struct {
+	apiKey   string
+	fromAddr string
+	client   *http.Client
+}
+
+func NewResendSender(apiKey, fromAddr string) *ResendSender {
+	return &ResendSender{
+		apiKey:   apiKey,
+		fromAddr: fromAddr,
+		client:   &http.Client{},
+	}
+}
+
+type sendEmailRequest struct {
+	From    string   `json:"from"`
+	To      []string `json:"to"`
+	Subject string   `json:"subject"`
+	HTML    string   `json:"html"`
+}
+
+func (r *ResendSender) Send(to, subject, html string) error {
+	if r.apiKey == "" {
+		slog.Info("email (dev mode — no RESEND_API_KEY set)",
+			"to", to,
+			"subject", subject,
+			"body", html,
+		)
+		return nil
+	}
+
+	body, err := json.Marshal(sendEmailRequest{
+		From:    r.fromAddr,
+		To:      []string{to},
+		Subject: subject,
+		HTML:    html,
+	})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://api.resend.com/emails", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+r.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("resend: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}

--- a/knowledgeable/internal/ratelimit/limiter.go
+++ b/knowledgeable/internal/ratelimit/limiter.go
@@ -1,0 +1,86 @@
+package ratelimit
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// IPLimiter is a sliding-window rate limiter keyed by IP address.
+type IPLimiter struct {
+	mu       sync.Mutex
+	requests map[string][]time.Time
+	max      int
+	window   time.Duration
+}
+
+func NewIPLimiter(max int, window time.Duration) *IPLimiter {
+	l := &IPLimiter{
+		requests: make(map[string][]time.Time),
+		max:      max,
+		window:   window,
+	}
+	go l.cleanup()
+	return l
+}
+
+func (l *IPLimiter) Allow(ip string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := time.Now()
+	cutoff := now.Add(-l.window)
+
+	prev := l.requests[ip]
+	valid := prev[:0]
+	for _, t := range prev {
+		if t.After(cutoff) {
+			valid = append(valid, t)
+		}
+	}
+
+	if len(valid) >= l.max {
+		l.requests[ip] = valid
+		return false
+	}
+
+	l.requests[ip] = append(valid, now)
+	return true
+}
+
+// cleanup removes stale entries once per window to prevent unbounded memory growth.
+func (l *IPLimiter) cleanup() {
+	ticker := time.NewTicker(l.window)
+	defer ticker.Stop()
+	for range ticker.C {
+		l.mu.Lock()
+		cutoff := time.Now().Add(-l.window)
+		for ip, times := range l.requests {
+			valid := times[:0]
+			for _, t := range times {
+				if t.After(cutoff) {
+					valid = append(valid, t)
+				}
+			}
+			if len(valid) == 0 {
+				delete(l.requests, ip)
+			} else {
+				l.requests[ip] = valid
+			}
+		}
+		l.mu.Unlock()
+	}
+}
+
+// RealIP returns the client IP, preferring X-Real-IP set by nginx over RemoteAddr.
+func RealIP(r *http.Request) string {
+	if ip := r.Header.Get("X-Real-IP"); ip != "" {
+		return ip
+	}
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return ip
+}

--- a/knowledgeable/internal/users/model.go
+++ b/knowledgeable/internal/users/model.go
@@ -1,5 +1,6 @@
 package users
 
+import "time"
 
 type User struct {
 	ID                   int64
@@ -7,4 +8,13 @@ type User struct {
 	Email                string
 	PasswordHash         string
 	ShouldChangePassword bool
+}
+
+type PasswordResetToken struct {
+	ID        int64
+	UserID    int64
+	TokenHash string
+	ExpiresAt time.Time
+	UsedAt    *time.Time
+	CreatedAt time.Time
 }

--- a/knowledgeable/internal/users/repository.go
+++ b/knowledgeable/internal/users/repository.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/lib/pq"
 )
@@ -90,6 +91,65 @@ func (r *Repository) UpdatePassword(userID int64, newPasswordHash string) error 
 	_, err := r.db.Exec(
 		"UPDATE users SET password_hash = $1, should_change_password = false WHERE id = $2",
 		newPasswordHash, userID,
+	)
+	return err
+}
+
+func (r *Repository) FindByEmail(email string) (*User, error) {
+	row := r.db.QueryRow(
+		"SELECT id, username, email, password_hash, should_change_password FROM users WHERE email = $1",
+		email,
+	)
+
+	var user User
+	err := row.Scan(&user.ID, &user.Username, &user.Email, &user.PasswordHash, &user.ShouldChangePassword)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &user, nil
+}
+
+func (r *Repository) CreatePasswordResetToken(userID int64, tokenHash string, expiresAt time.Time) error {
+	_, err := r.db.Exec(
+		"INSERT INTO password_reset_tokens (user_id, token_hash, expires_at) VALUES ($1, $2, $3)",
+		userID, tokenHash, expiresAt,
+	)
+	return err
+}
+
+func (r *Repository) FindPasswordResetToken(tokenHash string) (*PasswordResetToken, error) {
+	row := r.db.QueryRow(
+		"SELECT id, user_id, token_hash, expires_at, used_at, created_at FROM password_reset_tokens WHERE token_hash = $1",
+		tokenHash,
+	)
+
+	var token PasswordResetToken
+	var usedAt sql.NullTime
+	err := row.Scan(&token.ID, &token.UserID, &token.TokenHash, &token.ExpiresAt, &usedAt, &token.CreatedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if usedAt.Valid {
+		token.UsedAt = &usedAt.Time
+	}
+
+	return &token, nil
+}
+
+func (r *Repository) MarkTokenUsed(id int64) error {
+	_, err := r.db.Exec(
+		"UPDATE password_reset_tokens SET used_at = NOW() WHERE id = $1",
+		id,
 	)
 	return err
 }

--- a/knowledgeable/internal/users/repository.go
+++ b/knowledgeable/internal/users/repository.go
@@ -147,11 +147,21 @@ func (r *Repository) FindPasswordResetToken(tokenHash string) (*PasswordResetTok
 }
 
 func (r *Repository) MarkTokenUsed(id int64) error {
-	_, err := r.db.Exec(
-		"UPDATE password_reset_tokens SET used_at = NOW() WHERE id = $1",
+	res, err := r.db.Exec(
+		"UPDATE password_reset_tokens SET used_at = NOW() WHERE id = $1 AND used_at IS NULL AND expires_at > NOW()",
 		id,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	ra, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if ra == 0 {
+		return errors.New("token already used or expired")
+	}
+	return nil
 }
 
 func (r *Repository) FindAll() ([]User, error) {

--- a/knowledgeable/internal/users/service.go
+++ b/knowledgeable/internal/users/service.go
@@ -1,7 +1,11 @@
 package users
 
 import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"time"
 
 	"golang.org/x/crypto/bcrypt"
 )
@@ -9,9 +13,13 @@ import (
 type UserRepository interface {
 	Register(*User) error
 	FindByUsername(string) (*User, error)
+	FindByEmail(string) (*User, error)
 	FindById(int64) (*User, error)
 	FindAll() ([]User, error)
 	UpdatePassword(int64, string) error
+	CreatePasswordResetToken(userID int64, tokenHash string, expiresAt time.Time) error
+	FindPasswordResetToken(tokenHash string) (*PasswordResetToken, error)
+	MarkTokenUsed(id int64) error
 }
 
 type Service struct {
@@ -109,6 +117,59 @@ func (s *Service) ChangePassword(userID int64, newPassword string) error {
 	}
 
 	return s.repo.UpdatePassword(userID, string(hashed))
+}
+
+func (s *Service) GetByEmail(email string) (*User, error) {
+	if email == "" {
+		return nil, errors.New("missing email")
+	}
+	return s.repo.FindByEmail(email)
+}
+
+func (s *Service) CreateResetToken(userID int64) (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	rawToken := hex.EncodeToString(b)
+
+	sum := sha256.Sum256([]byte(rawToken))
+	tokenHash := hex.EncodeToString(sum[:])
+
+	if err := s.repo.CreatePasswordResetToken(userID, tokenHash, time.Now().Add(time.Hour)); err != nil {
+		return "", err
+	}
+
+	return rawToken, nil
+}
+
+func (s *Service) ConsumeResetToken(rawToken string) (int64, error) {
+	if rawToken == "" {
+		return 0, errors.New("missing token")
+	}
+
+	sum := sha256.Sum256([]byte(rawToken))
+	tokenHash := hex.EncodeToString(sum[:])
+
+	token, err := s.repo.FindPasswordResetToken(tokenHash)
+	if err != nil {
+		return 0, err
+	}
+	if token == nil {
+		return 0, errors.New("invalid token")
+	}
+	if time.Now().After(token.ExpiresAt) {
+		return 0, errors.New("token expired")
+	}
+	if token.UsedAt != nil {
+		return 0, errors.New("token already used")
+	}
+
+	if err := s.repo.MarkTokenUsed(token.ID); err != nil {
+		return 0, err
+	}
+
+	return token.UserID, nil
 }
 
 func (s *Service) GetAll() ([]User, error) {

--- a/knowledgeable/internal/users/service_test.go
+++ b/knowledgeable/internal/users/service_test.go
@@ -3,13 +3,15 @@ package users
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"golang.org/x/crypto/bcrypt"
 )
 
 type mockRepo struct {
-	user *User
-	err  error
+	user  *User
+	token *PasswordResetToken
+	err   error
 }
 
 func (m *mockRepo) Register(u *User) error {
@@ -40,6 +42,22 @@ func (m *mockRepo) FindAll() ([]User, error) {
 		return nil, m.err
 	}
 	return []User{*m.user}, nil
+}
+
+func (m *mockRepo) FindByEmail(email string) (*User, error) {
+	return m.user, m.err
+}
+
+func (m *mockRepo) CreatePasswordResetToken(userID int64, tokenHash string, expiresAt time.Time) error {
+	return m.err
+}
+
+func (m *mockRepo) FindPasswordResetToken(tokenHash string) (*PasswordResetToken, error) {
+	return m.token, m.err
+}
+
+func (m *mockRepo) MarkTokenUsed(id int64) error {
+	return m.err
 }
 
 // HAPPY PATH
@@ -163,5 +181,123 @@ func TestGetByID_NotFound(t *testing.T) {
 	_, err := service.GetByID(1)
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+// GetByEmail
+func TestGetByEmail_Success(t *testing.T) {
+	repo := &mockRepo{user: &User{ID: 1, Email: "rasmus@test.com"}}
+	service := NewService(repo)
+
+	user, err := service.GetByEmail("rasmus@test.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if user.Email != "rasmus@test.com" {
+		t.Fatal("wrong user returned")
+	}
+}
+
+func TestGetByEmail_MissingEmail(t *testing.T) {
+	service := NewService(&mockRepo{})
+
+	_, err := service.GetByEmail("")
+	if err == nil {
+		t.Fatal("expected error for empty email")
+	}
+}
+
+// CreateResetToken
+func TestCreateResetToken_Success(t *testing.T) {
+	repo := &mockRepo{}
+	service := NewService(repo)
+
+	token, err := service.CreateResetToken(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+}
+
+func TestCreateResetToken_RepoError(t *testing.T) {
+	repo := &mockRepo{err: errors.New("db failed")}
+	service := NewService(repo)
+
+	_, err := service.CreateResetToken(1)
+	if err == nil {
+		t.Fatal("expected repo error")
+	}
+}
+
+// ConsumeResetToken
+func TestConsumeResetToken_Success(t *testing.T) {
+	validToken := &PasswordResetToken{
+		ID:        1,
+		UserID:    42,
+		ExpiresAt: time.Now().Add(time.Hour),
+		UsedAt:    nil,
+	}
+	repo := &mockRepo{token: validToken}
+	service := NewService(repo)
+
+	userID, err := service.ConsumeResetToken("anyrawtoken")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if userID != 42 {
+		t.Fatalf("expected userID 42, got %d", userID)
+	}
+}
+
+func TestConsumeResetToken_Empty(t *testing.T) {
+	service := NewService(&mockRepo{})
+
+	_, err := service.ConsumeResetToken("")
+	if err == nil {
+		t.Fatal("expected error for empty token")
+	}
+}
+
+func TestConsumeResetToken_NotFound(t *testing.T) {
+	repo := &mockRepo{token: nil}
+	service := NewService(repo)
+
+	_, err := service.ConsumeResetToken("unknowntoken")
+	if err == nil {
+		t.Fatal("expected error for unknown token")
+	}
+}
+
+func TestConsumeResetToken_Expired(t *testing.T) {
+	expired := &PasswordResetToken{
+		ID:        1,
+		UserID:    42,
+		ExpiresAt: time.Now().Add(-time.Hour),
+	}
+	repo := &mockRepo{token: expired}
+	service := NewService(repo)
+
+	_, err := service.ConsumeResetToken("anyrawtoken")
+	if err == nil {
+		t.Fatal("expected error for expired token")
+	}
+}
+
+func TestConsumeResetToken_AlreadyUsed(t *testing.T) {
+	usedAt := time.Now().Add(-time.Minute)
+	used := &PasswordResetToken{
+		ID:        1,
+		UserID:    42,
+		ExpiresAt: time.Now().Add(time.Hour),
+		UsedAt:    &usedAt,
+	}
+	repo := &mockRepo{token: used}
+	service := NewService(repo)
+
+	_, err := service.ConsumeResetToken("anyrawtoken")
+	if err == nil {
+		t.Fatal("expected error for already-used token")
 	}
 }

--- a/knowledgeable/internal/web/router.go
+++ b/knowledgeable/internal/web/router.go
@@ -33,6 +33,8 @@ func SetupRoutes(
 	http.HandleFunc("/api/login", authHandler.LoginAPI)
 	http.HandleFunc("/api/me", authHandler.Me)
 	http.HandleFunc("/change-password", authHandler.ChangePassword)
+	http.HandleFunc("/forgot-password", authHandler.ForgotPassword)
+	http.HandleFunc("/reset-password", authHandler.ResetPassword)
 
 	http.Handle("/metrics", promhttp.Handler())
 

--- a/knowledgeable/templates/forgot_password.html
+++ b/knowledgeable/templates/forgot_password.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Forgot Password</title>
+    <link href="/static/output.css" rel="stylesheet">
+    <link rel="icon" href="/static/favicon.png" />
+</head>
+
+<body class="min-h-screen flex flex-col">
+
+    <div
+        class="relative w-screen h-screen bg-[url('/static/grid-green.svg')] bg-repeat flex items-center justify-center flex-col font-sans tracking-tight">
+        <div
+            class="absolute inset-x-0 bottom-0 top-16 pointer-events-none bg-[radial-gradient(ellipse_80%_80%_at_50%_50%,transparent_30%,#0a0e17_100%)]">
+        </div>
+
+        <div
+            class="w-fit h-fit border border-[#242422] bg-[#090d16] flex flex-col justify-center items-center rounded-lg z-10 p-6 gap-4">
+
+            {{if .Sent}}
+            <div class="flex flex-col w-72 gap-3">
+                <h1 class="text-xl font-semibold text-white">Check your email</h1>
+                <p class="text-gray-400 text-sm">If that address is registered, you'll receive a reset link shortly.</p>
+                <a href="/login" class="w-72 block text-center bg-[#1eff8c] hover:bg-[#38be7d] text-black font-bold py-2 rounded transition mt-2">
+                    Back to login
+                </a>
+            </div>
+            {{else}}
+            <form method="POST" action="/forgot-password" class="flex flex-col gap-5 items-center">
+
+                <div class="flex flex-col w-72">
+                    <h1 class="text-xl font-semibold text-white">Reset your password</h1>
+                    <span class="text-gray-400 text-sm">Enter your email and we'll send you a reset link</span>
+                </div>
+
+                {{if .Error}}
+                <div class="w-72 bg-red-950/40 border border-red-800 rounded px-3 py-2 text-red-400 text-sm">
+                    {{.Error}}
+                </div>
+                {{end}}
+
+                <div class="flex flex-col w-72">
+                    <label for="email" class="text-sm text-gray-400 mb-1">EMAIL</label>
+                    <input
+                        class="w-72 bg-[#0f172a] border border-gray-800 rounded px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-green-500"
+                        id="email" name="email" type="email" required>
+                </div>
+
+                <button class="w-72 bg-[#1eff8c] hover:bg-[#38be7d] text-black font-bold py-2 rounded transition mt-2" type="submit">
+                    Send reset link
+                </button>
+            </form>
+
+            <div class="flex flex-row justify-center items-center gap-1 w-72">
+                <span class="text-gray-500 text-sm">Remember your password?</span>
+                <a href="/login" class="text-[#1eff8c] text-sm hover:text-[#38be7d]">Log in</a>
+            </div>
+            {{end}}
+
+        </div>
+
+    </div>
+
+</body>
+
+</html>

--- a/knowledgeable/templates/reset_password.html
+++ b/knowledgeable/templates/reset_password.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <title>Login</title>
+    <title>Reset Password</title>
     <link href="/static/output.css" rel="stylesheet">
     <link rel="icon" href="/static/favicon.png" />
 </head>
@@ -15,15 +15,16 @@
             class="absolute inset-x-0 bottom-0 top-16 pointer-events-none bg-[radial-gradient(ellipse_80%_80%_at_50%_50%,transparent_30%,#0a0e17_100%)]">
         </div>
 
-
         <div
             class="w-fit h-fit border border-[#242422] bg-[#090d16] flex flex-col justify-center items-center rounded-lg z-10 p-6 gap-4">
 
-            <form method="POST" action="/api/login" class="flex flex-col gap-5 items-center">
+            <form method="POST" action="/reset-password" class="flex flex-col gap-5 items-center">
+
+                <input type="hidden" name="token" value="{{.Token}}">
 
                 <div class="flex flex-col w-72">
-                    <h1 class="text-xl font-semibold text-white">Welcome back</h1>
-                    <span class="text-gray-400 text-sm">Log in to your account</span>
+                    <h1 class="text-xl font-semibold text-white">Set new password</h1>
+                    <span class="text-gray-400 text-sm">Choose a strong password for your account</span>
                 </div>
 
                 {{if .Error}}
@@ -33,51 +34,45 @@
                 {{end}}
 
                 <div class="flex flex-col w-72">
-                    <label for="username" class="text-sm text-gray-400 mb-1">USERNAME</label>
+                    <label for="password" class="text-sm text-gray-400 mb-1">NEW PASSWORD</label>
                     <input
                         class="w-72 bg-[#0f172a] border border-gray-800 rounded px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-green-500"
-                        id="username" name="username" type="text" required>
+                        id="password" name="password" type="password" required minlength="8">
                 </div>
 
                 <div class="flex flex-col w-72">
-                    <label for="password" class="text-sm text-gray-400 mb-1">PASSWORD</label>
+                    <label for="confirm_password" class="text-sm text-gray-400 mb-1">CONFIRM PASSWORD</label>
                     <input
                         class="w-72 bg-[#0f172a] border border-gray-800 rounded px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-green-500"
-                        id="password" name="password" type="password" required>
+                        id="confirm_password" name="confirm_password" type="password" required minlength="8">
+                    <span id="match-error" class="text-red-400 text-xs mt-1 hidden">Passwords do not match</span>
                 </div>
 
                 <button class="w-72 bg-[#1eff8c] hover:bg-[#38be7d] text-black font-bold py-2 rounded transition mt-2" type="submit">
-                    Log in
+                    Reset password
                 </button>
-
-                <a href="/forgot-password" class="text-[#1eff8c] text-sm hover:text-[#38be7d] self-start -mt-2">
-                    Forgot password?
-                </a>
             </form>
-
-            <div class="flex items-center gap-3 w-72">
-                <div class="flex-1 h-px bg-[#1e2533]"></div>
-                <span class="text-xs text-gray-600">or</span>
-                <div class="flex-1 h-px bg-[#1e2533]"></div>
-            </div>
-
-            <a href="/"
-                class="w-72 block text-center hover:bg-[#121a2d] text-gray-400 font-medium py-2 transition border border-gray-800 rounded">
-                Continue without logging in
-            </a>
-
-            <div class="flex flex-row justify-center items-center gap-1 w-72">
-                <span class="text-gray-500 text-sm">Don't have an account?</span>
-                <a href="/register" class="text-[#1eff8c] text-sm hover:text-[#38be7d]">Sign up</a>
-            </div>
 
         </div>
 
     </div>
 
-    <script src="https://unpkg.com/lucide@latest"></script>
     <script>
-        lucide.createIcons();
+        const form = document.querySelector('form');
+        const pw = document.getElementById('password');
+        const confirm = document.getElementById('confirm_password');
+        const error = document.getElementById('match-error');
+
+        form.addEventListener('submit', (e) => {
+            if (pw.value !== confirm.value) {
+                e.preventDefault();
+                error.classList.remove('hidden');
+            }
+        });
+
+        confirm.addEventListener('input', () => {
+            error.classList.toggle('hidden', pw.value === confirm.value);
+        });
     </script>
 </body>
 

--- a/scripts/run_golang_lint.sh
+++ b/scripts/run_golang_lint.sh
@@ -10,7 +10,7 @@ echo "Running golangci-lint in $PROJECT_DIR ..."
 if ! command -v golangci-lint > /dev/null 2>&1; then
   echo "ERROR: golangci-lint is not installed or not in PATH."
   echo "Install v${REQUIRED_VERSION#v}:"
-  echo "  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b \$(go env GOPATH)/bin $REQUIRED_VERSION"
+  echo "   go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4  "
   exit 1
 fi
 

--- a/scripts/run_golang_lint.sh
+++ b/scripts/run_golang_lint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Runs golangci-lint inside the knowledgeable Go project
 
+REQUIRED_VERSION="v2.11.4"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 PROJECT_DIR="$REPO_ROOT/knowledgeable"
 
@@ -8,7 +9,17 @@ echo "Running golangci-lint in $PROJECT_DIR ..."
 
 if ! command -v golangci-lint > /dev/null 2>&1; then
   echo "ERROR: golangci-lint is not installed or not in PATH."
-  echo "Install it from: https://golangci-lint.run/usage/install/"
+  echo "Install v${REQUIRED_VERSION#v}:"
+  echo "  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b \$(go env GOPATH)/bin $REQUIRED_VERSION"
+  exit 1
+fi
+
+INSTALLED_VERSION="v$(golangci-lint --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+
+if [ "$INSTALLED_VERSION" != "$REQUIRED_VERSION" ]; then
+  echo "ERROR: golangci-lint $REQUIRED_VERSION required, but $INSTALLED_VERSION is installed."
+  echo "Install the correct version:"
+  echo "  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b \$(go env GOPATH)/bin $REQUIRED_VERSION"
   exit 1
 fi
 


### PR DESCRIPTION
## What
Implements a forgot password flow using Resend as the email provider. Users can request a password reset link from the login page, receive an email with a time-limited token, and set a new password via a reset form.

POST /forgot-password — looks up user by email, generates a SHA-256 hashed token (1h TTL), sends a reset link via Resend
GET/POST /reset-password — validates and consumes the token, updates the password
New password_reset_tokens table with indexes on token_hash and user_id
New internal/email package with a Resend HTTP sender (falls back to stdout logging when RESEND_API_KEY is unset)

## Why
Users had no self-service way to recover access to their account if they forgot their password. An admin had to manually reset it via the should_change_password flag.

## Related Issue
Closes #272 

## Type 
- [x] Feature
- [] Bug
- [] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [x] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password reset flow: "Forgot password" and "Reset password" pages, plus a password-recovery link from the login page.
  * Email delivery for password recovery (configurable via environment).

* **Chores**
  * Database migration to store password reset tokens.
  * Deployment and local env updated to include email and app base URL settings.
  * Docker and ignore rules updated for new config files.
  * Lint tooling script enforces a specific version.

* **Tests**
  * Expanded integration and service tests covering password reset flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->