### PR TITLE
Chore/webcrawling

### DIFF
--- a/knowledgeable/db-migrations/migrations/20260426123000_cleanup_wayback_urls.js
+++ b/knowledgeable/db-migrations/migrations/20260426123000_cleanup_wayback_urls.js
@@ -1,0 +1,57 @@
+export async function up(knex) {
+  const pattern = '^https?://web\\.archive\\.org/web/[0-9]+\\*?/(https?://.+)$';
+
+  await knex.transaction(async (trx) => {
+    await trx.raw(
+      `
+      WITH normalized AS (
+        SELECT
+          id,
+          regexp_replace(url, ?, '\\1') AS normalized_url
+        FROM pages
+        WHERE url ~ ?
+      ),
+      conflicts AS (
+        SELECT n.id
+        FROM normalized n
+        JOIN pages p ON p.url = n.normalized_url AND p.id <> n.id
+      )
+      DELETE FROM pages
+      WHERE id IN (SELECT id FROM conflicts)
+      `,
+      [pattern, pattern]
+    );
+
+    await trx.raw(
+      `
+      WITH normalized AS (
+        SELECT
+          id,
+          regexp_replace(url, ?, '\\1') AS normalized_url,
+          ROW_NUMBER() OVER (
+            PARTITION BY regexp_replace(url, ?, '\\1')
+            ORDER BY last_updated DESC, id DESC
+          ) AS rn
+        FROM pages
+        WHERE url ~ ?
+      )
+      DELETE FROM pages
+      WHERE id IN (SELECT id FROM normalized WHERE rn > 1)
+      `,
+      [pattern, pattern, pattern]
+    );
+
+    await trx.raw(
+      `
+      UPDATE pages
+      SET url = regexp_replace(url, ?, '\\1')
+      WHERE url ~ ?
+      `,
+      [pattern, pattern]
+    );
+  });
+}
+
+export async function down() {
+  // Irreversible data cleanup migration.
+}

--- a/knowledgeable/db-migrations/migrations/20260426124000_block_wayback_urls_constraint.js
+++ b/knowledgeable/db-migrations/migrations/20260426124000_block_wayback_urls_constraint.js
@@ -1,0 +1,22 @@
+export async function up(knex) {
+  await knex.raw(`
+    ALTER TABLE pages
+    ADD CONSTRAINT pages_url_not_wayback_wrapper
+    CHECK (
+      url !~ '^https?://web\\.archive\\.org/web/[0-9]+\\*?/(https?://.+)$'
+    )
+    NOT VALID
+  `);
+
+  await knex.raw(`
+    ALTER TABLE pages
+    VALIDATE CONSTRAINT pages_url_not_wayback_wrapper
+  `);
+}
+
+export async function down(knex) {
+  await knex.raw(`
+    ALTER TABLE pages
+    DROP CONSTRAINT IF EXISTS pages_url_not_wayback_wrapper
+  `);
+}

--- a/knowledgeable/scripts/crawler.js
+++ b/knowledgeable/scripts/crawler.js
@@ -24,6 +24,15 @@ function delay(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function unwrapWaybackUrl(urlString) {
+    const waybackPattern = /^https?:\/\/web\.archive\.org\/web\/\d+\*?\/(https?:\/\/.+)$/;
+    const match = urlString.match(waybackPattern);
+    if (match) {
+        return match[1];
+    }
+    return urlString;
+}
+
 function asSeedURL(rawTarget) {
     const trimmed = (rawTarget || '').trim();
     if (!trimmed) {
@@ -131,7 +140,7 @@ async function crawlPage(pageUrl, depth = 0) {
 
         pagesToIngest.push({
             title,
-            url: cleanUrl.href,
+            url: unwrapWaybackUrl(cleanUrl.href),
             language: 'en',
             content: mainContent
         });


### PR DESCRIPTION
## What
Unwraps wyback url
## Why
So url's in search enginge are valid
## Related Issue
Closes #

## Type 
- [] Feature
- [x] Bug
- [] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed legacy archived URL references from the database, retaining only the highest-priority entries to improve data quality
  * Added validation rules to prevent problematic URL formats from being stored in the future

* **Improvements**
  * Web crawler now properly extracts original URLs when processing archived sources, ensuring accurate URL storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->