### PR TITLE
docs: deleted invenetory and stopped workflow after teardown

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -1,7 +1,7 @@
 name: Drift Check
 on:
-  schedule:
-    - cron: '0 3 * * *'    # 3 AM UTC daily
+  #schedule:
+  #  - cron: '0 3 * * *'    # 3 AM UTC daily
   workflow_dispatch:
 
 jobs:

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,5 +1,2 @@
-[knowledge]
-51.120.83.236 ansible_user=azureuser
-
-[kmonitor]
-20.100.200.117 ansible_user=azureuser
+# Inventory regenerated after `terraform apply`. See runbook step 2.
+# All hosts torn down — re-provision before running playbooks.


### PR DESCRIPTION
## What
due to the fact that we have two original vms outside terraform, we need to shut those down, within a week or so, then bring up the new ones via tf. Those will be supported with drift checking

i have teared the new vms down and commented out workflows and the inventory

## Why
improve our infrastructure

## Related Issue
Closes #

## Type 
- [] Feature
- [] Bug
- [x] Chore
- [x] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic daily drift check execution; manual workflow triggers remain available
  * Updated infrastructure inventory configuration; system re-provisioning required

<!-- end of auto-generated comment: release notes by coderabbit.ai -->