### PR TITLE
fix(e2e): changed migrations to run correctly in staging

### DIFF
--- a/.github/scripts/deploy-staging.sh
+++ b/.github/scripts/deploy-staging.sh
@@ -24,10 +24,10 @@ if [ "$DB_READY" -eq 0 ]; then
   exit 1
 fi
 echo "[DEPLOY] Run migrations"
-docker compose -p staging -f docker-compose-staging.yml --profile tools run --rm --entrypoint sh migrations -c "npx knex migrate:latest"
+docker compose -p staging -f docker-compose-staging.yml --profile tools run --rm migrations migrate:latest
 
 echo "[DEPLOY] Run seed"
-docker compose -p staging -f docker-compose-staging.yml --profile tools run --rm --entrypoint sh migrations -c "npx knex seed:run --specific=staging_seed.js"
+docker compose -p staging -f docker-compose-staging.yml --profile tools run --rm migrations seed:run --specific=staging_seed.js
 echo "[DEPLOY] Start app"
 docker compose -p staging -f docker-compose-staging.yml up -d --remove-orphans app
 echo "[DEPLOY] Checking containers"

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           ssh -i ~/.ssh/ssh_key -o StrictHostKeyChecking=no \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
-            "CR_PAT='${{ secrets.CR__PAT }}' DOCKER_USERNAME='${{ secrets.DOCKER_USERNAME }}' CRAWLER_KEY='${{ secrets.CRAWLER_KEY }}' bash ~/app/deploy-staging.sh"
+            "CR_PAT='${{ secrets.CR__PAT }}' DOCKER_USERNAME='${{ secrets.DOCKER_USERNAME }}' CRAWLER_KEY='${{ secrets.CRAWLER_KEY }}' DATABASE_URL='${{ secrets.DATABASE_URL }}' bash ~/app/deploy-staging.sh"
 
       - name: Wait for staging app
         run: |

--- a/knowledgeable/db-migrations/knexfile.js
+++ b/knowledgeable/db-migrations/knexfile.js
@@ -7,7 +7,7 @@ dotenv.config({});
 
 export default {
   client: 'postgresql',
-  connection: {
+  connection: process.env.DATABASE_URL || {
     database: process.env.POSTGRES_DB,
     user: process.env.POSTGRES_USER,
     password: process.env.POSTGRES_PASSWORD,

--- a/knowledgeable/docker-compose-staging.yml
+++ b/knowledgeable/docker-compose-staging.yml
@@ -25,7 +25,7 @@ services:
     restart: "no"
     profiles: ["tools"]
     environment:
-      DATABASE_URL: postgres://postgres:postgres@db:5432/knowledgeable?sslmode=disable
+      DATABASE_URL: ${DATABASE_URL}
       POSTGRES_DB: knowledgeable
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -46,7 +46,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_HOST: db
       APP_ENV: staging
-      DATABASE_URL: postgres://postgres:postgres@db:5432/knowledgeable?sslmode=disable
+      DATABASE_URL: ${DATABASE_URL}
       CRAWLER_KEY: ${CRAWLER_KEY}
     ports:
       - "8081:8080"

--- a/knowledgeable/docker-compose-staging.yml
+++ b/knowledgeable/docker-compose-staging.yml
@@ -25,6 +25,7 @@ services:
     restart: "no"
     profiles: ["tools"]
     environment:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/knowledgeable?sslmode=disable
       POSTGRES_DB: knowledgeable
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
## What
What has been implemented?
- fxied staging migration execution by using korrect knex command
- added database_url to migration service to ensure consistent db connection
- updated knexfile to support databaseurl fallback
- removed incorrect --entrypoint sh usage in staging deploy script
## Why
Why is this change needed?
migrations were not applied to the staging database due to incorrect command execution and unreliable environment variable injection.


## Type 
- [] Feature
- [x] Bug
- [] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration and seeding processes in the staging deployment workflow for improved execution handling.
  * Enhanced database connectivity configuration to support alternative connection string formats, providing greater flexibility in connection setup while maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->