### PR TITLE
fix(staging): added db config via database_url and removed postgres_ …

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           ssh -i ~/.ssh/ssh_key -o StrictHostKeyChecking=no \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
-            "CR_PAT='${{ secrets.CR__PAT }}' DOCKER_USERNAME='${{ secrets.DOCKER_USERNAME }}' CRAWLER_KEY='${{ secrets.CRAWLER_KEY }}' DATABASE_URL='${{ secrets.DATABASE_URL }}' bash ~/app/deploy-staging.sh"
+            "CR_PAT='${{ secrets.CR__PAT }}' DOCKER_USERNAME='${{ secrets.DOCKER_USERNAME }}' CRAWLER_KEY='${{ secrets.CRAWLER_KEY }}' DATABASE_URL='${{ secrets.STAGING_DATABASE_URL }}' bash ~/app/deploy-staging.sh"
 
       - name: Wait for staging app
         run: |

--- a/knowledgeable/docker-compose-staging.yml
+++ b/knowledgeable/docker-compose-staging.yml
@@ -26,10 +26,6 @@ services:
     profiles: ["tools"]
     environment:
       DATABASE_URL: ${DATABASE_URL}
-      POSTGRES_DB: knowledgeable
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_HOST: db
     networks:
       - staging
 
@@ -41,10 +37,6 @@ services:
           condition: service_healthy
     restart: unless-stopped
     environment:
-      POSTGRES_DB: knowledgeable
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_HOST: db
       APP_ENV: staging
       DATABASE_URL: ${DATABASE_URL}
       CRAWLER_KEY: ${CRAWLER_KEY}


### PR DESCRIPTION
## What

Cleaned up the staging config so both the app and migrations only use `DATABASE_URL`. Removed the old `POSTGRES_*` variables from the compose file.

## Why

There was a mismatch in database credentials which caused the app to fail on startup and migrations to sometimes run against the wrong database.


## Type

* [x] Bug
* [x] Chore

## Definition of Done

* [x] Staging app starts correctly
* [x] Migrations and seed run reliably
* [x] No more DB auth/connection errors
