### PR TITLE
fix(staging): added run migrations and seed in single container

### DIFF
--- a/.github/scripts/deploy-staging.sh
+++ b/.github/scripts/deploy-staging.sh
@@ -23,11 +23,10 @@ if [ "$DB_READY" -eq 0 ]; then
   echo "[DEPLOY] ERROR: DB never became ready"
   exit 1
 fi
-echo "[DEPLOY] Run migrations"
-docker compose -p staging -f docker-compose-staging.yml --profile tools run --rm migrations migrate:latest
-
-echo "[DEPLOY] Run seed"
-docker compose -p staging -f docker-compose-staging.yml --profile tools run --rm migrations seed:run --specific=staging_seed.js
+echo "[DEPLOY] Run migrations + seed"
+docker compose -p staging -f docker-compose-staging.yml \
+  --profile tools run --rm migrations sh -c "knex migrate:latest && knex seed:run --specific=staging_seed.js"
+  
 echo "[DEPLOY] Start app"
 docker compose -p staging -f docker-compose-staging.yml up -d --remove-orphans app
 echo "[DEPLOY] Checking containers"


### PR DESCRIPTION
## What

Changed the staging deploy script so migrations and seed run in the same container instead of separate runs.

## Why

Running them separately caused connection issues to the database. This makes sure both steps use the same setup and actually hit the correct DB.

## Related Issue


## Type
* [x] Bug

## Definition of Done

* [x] Deploy script updated
* [x] Migrations and seed run without errors
* [x] App starts and connects to DB
