### PR TITLE
fix(staging): fixed run migrations and seed with overridden entrypoin…

### DIFF
--- a/.github/scripts/deploy-staging.sh
+++ b/.github/scripts/deploy-staging.sh
@@ -25,8 +25,8 @@ if [ "$DB_READY" -eq 0 ]; then
 fi
 echo "[DEPLOY] Run migrations + seed"
 docker compose -p staging -f docker-compose-staging.yml \
-  --profile tools run --rm migrations sh -c "knex migrate:latest && knex seed:run --specific=staging_seed.js"
-  
+  --profile tools run --rm --entrypoint sh migrations -c "knex migrate:latest && knex seed:run --specific=staging_seed.js"
+
 echo "[DEPLOY] Start app"
 docker compose -p staging -f docker-compose-staging.yml up -d --remove-orphans app
 echo "[DEPLOY] Checking containers"


### PR DESCRIPTION
## What

Updated the staging deploy script so migrations and seed run through a shell instead of the default entrypoint.

## Why

Before this, the container tried to run everything through knex directly, which broke when chaining commands. This change makes sure both migrations and seed actually run and can connect to the DB.

## Related Issue

Closes #

## Type

* [x] Bug

## Definition of Done

* [x] Deploy script updated
* [x] Migrations and seed run without crashing
* [x] App starts and connects to DB
