### PR TITLE
fix(staging): added ovverride database_url to prevent dotenv from usi…

### DIFF
--- a/knowledgeable/docker-compose-staging.yml
+++ b/knowledgeable/docker-compose-staging.yml
@@ -25,6 +25,8 @@ services:
     profiles: ["tools"]
     env_file:
       - .env.staging
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
     networks:
       - staging
 
@@ -37,6 +39,8 @@ services:
     restart: unless-stopped
     env_file:
       - .env.staging
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
     ports:
       - "8081:8080"
     networks:


### PR DESCRIPTION
…ng wrong config

## What
What has been implemented?
Fixed staging so it uses the correct database config.
## Why
Why is this change needed?
 It was connecting to the wrong DB and failing during deploy.
## Related Issue

## Type 
- [] Feature
- [x] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)

