### PR TITLE
chore(tf): removed the 2 vms, monitor deployment is ready

### DIFF
--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,5 +1,1 @@
-[knowledge]
-20.251.203.13 ansible_user=azureuser
-
-[kmonitor]
-20.251.212.14 ansible_user=azureuser
+#uploads the ip adresses for next tf apply


### PR DESCRIPTION
## What
took down the vms from tf
stagning shouwld work now, it was running on a stale image, whcih was removed manually
## Why
to not overpay

## Related Issue
Closes #

## Type 
- [] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)

