### PR TITLE
fix(crawler): changed settings for workflow run schedule, and max pag…

### DIFF
--- a/knowledgeable/internal/pages/handler.go
+++ b/knowledgeable/internal/pages/handler.go
@@ -348,24 +348,31 @@ func (h *Handler) CrawlerIngestAPI(w http.ResponseWriter, r *http.Request) {
 	}
 
 	upserted, err := h.service.IngestCrawlerPages(items)
-	if err != nil {
-		// Log error type, message, item count, and up to 5 sample URLs
-		sampleURLs := make([]string, 0, 5)
-		for _, item := range items {
-			sampleURLs = append(sampleURLs, item.URL)
-			if len(sampleURLs) >= 5 {
-				break
-			}
+	sampleURLs := make([]string, 0, 5)
+	for _, item := range items {
+		sampleURLs = append(sampleURLs, item.URL)
+		if len(sampleURLs) >= 5 {
+			break
 		}
-		slog.Error("crawler ingest failed",
-			"error_type", fmt.Sprintf("%T", err),
-			"error_msg", err.Error(),
+	}
+	if err != nil {
+		slog.Error("crawler_ingest_failed",
+			"event", "crawler_ingest_failed",
 			"items_count", len(items),
 			"sample_urls", sampleURLs,
+			"error_type", fmt.Sprintf("%T", err),
+			"error_msg", err.Error(),
 		)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
+	// Log success
+	slog.Info("crawler_ingest_success",
+		"event", "crawler_ingest_success",
+		"items_count", len(items),
+		"sample_urls", sampleURLs,
+		"upserted", upserted,
+	)
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(CrawlerIngestResponse{

--- a/knowledgeable/scripts/crawler.js
+++ b/knowledgeable/scripts/crawler.js
@@ -15,7 +15,7 @@ const SEED_URL_TEMPLATES = (process.env.SEED_URL_TEMPLATES || 'https://en.wikipe
     .filter(Boolean);
 
 const MAX_TARGETS = Number(process.env.MAX_TARGETS || 20);
-const MAX_PAGES = Number(process.env.MAX_PAGES || 200);
+const MAX_PAGES = Number(process.env.MAX_PAGES || 100);
 const MAX_DEPTH = Number(process.env.MAX_DEPTH || 2);
 const CRAWL_DELAY_MS = Number(process.env.CRAWL_DELAY_MS || 1000);
 const ENABLE_INGEST = String(process.env.ENABLE_INGEST || 'false').toLowerCase() === 'true';
@@ -319,10 +319,7 @@ async function main() {
 
     console.log(`[INFO] Crawl complete. Collected ${pagesToIngest.length} pages`);
     await sendBatchToBackend();
-    // To run this crawler every 12 hours, use a scheduler like cron or GitHub Actions scheduled workflows.
-    // This script does not implement scheduling itself.
-    // Example cron: 0 */12 * * *
-    // Example GitHub Actions: see docs for 'on: schedule'
+
 }
 
 main().catch((error) => {


### PR DESCRIPTION
…es to 100

## What
changes in webcrawler workflow
it willl not crawl max 100 pages evrey 12 h 

## Why
to sendt fewer rewuest in craweler job

## Related Issue
Closes #

## Type 
- [] Feature
- [x] Bug
- [] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced crawler ingestion logging with detailed error and success event tracking

* **Chores**
  * Reduced default maximum pages limit for crawler operations from 200 to 100

<!-- end of auto-generated comment: release notes by coderabbit.ai -->