### PR TITLE
feat(cd): added .env.previous rollback support in deployment workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -58,6 +58,15 @@ jobs:
           printf 'FROM_EMAIL=%s\n'        "$FROM_EMAIL"          >> .env
           printf 'APP_BASE_URL=https://%s\n' "$APP_DOMAIN"       >> .env
 
+      - name: Backup current env on server
+        run: |
+          ssh -i ~/.ssh/ssh_key ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} << "EOF"
+            set -e
+            if [ -f ~/app/.env ]; then
+              cp ~/app/.env ~/app/.env.previous
+            fi
+          EOF
+          
       - name: Transfer .env to server
         run: |
           scp -i ~/.ssh/ssh_key .env ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/app/.env


### PR DESCRIPTION
## What

- Added server-side backup of existing .env before deployment
- Copies /app/.env /app/.env.previous prior to overwrite

## Why
* Current deploy overwrites env and loses previous image_tag
* Enables rollback to last known working version
* Establishes foundation for future automated rollback

## Related Issue 3

Closes #317 
## Type
* [x] Feature
* [ ] Bug
* [ ] Chore
* [ ] Docs

## Definition of Done

* [x] Code implemented
* [ ] Tests added (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment reliability by implementing an automatic backup mechanism for configuration files during the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->