### PR TITLE
Feat/implement/post deploy/smoketest

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -99,3 +99,10 @@ jobs:
 
           echo "App failed to start"
           exit 1
+
+      - name: Run Playwright post-deploy smoke
+        env:
+          BASE_URL: https://${{ secrets.APP_DOMAIN }}
+          TEST_USER_USERNAME: ${{ secrets.TEST_USER_USERNAME }}
+          TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+        run: npx playwright test --project=post-deploy

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -99,10 +99,46 @@ jobs:
 
           echo "App failed to start"
           exit 1
+      
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        working-directory: knowledgeable
+        run: npm ci
+
+      - name: Install Playwright
+        working-directory: knowledgeable
+        run: npx playwright install --with-deps
 
       - name: Run Playwright post-deploy smoke
+        working-directory: knowledgeable
         env:
           BASE_URL: https://${{ secrets.APP_DOMAIN }}
           TEST_USER_USERNAME: ${{ secrets.TEST_USER_USERNAME }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
         run: npx playwright test --project=post-deploy
+
+      - name: Rollback on failure
+        if: failure()
+        run: |
+          ssh -i ~/.ssh/ssh_key ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} << "EOF"
+            set -e
+            cd ~/app
+
+            if [ -f .env.previous ]; then
+              echo "Current version:"
+              grep IMAGE_TAG .env || true
+
+              echo "Rolling back to:"
+              grep IMAGE_TAG .env.previous || true
+
+              cp .env.previous .env
+              docker compose pull
+              docker compose up -d --remove-orphans
+            else
+              echo "No previous version found"
+              exit 1
+            fi
+          EOF

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -85,3 +85,17 @@ jobs:
             docker compose up -d --no-deps --force-recreate nginx
             docker compose ps
           EOF
+
+      - name: Wait for app to be ready
+        run: |
+          for i in {1..15}; do
+            if curl -sf https://${{ secrets.APP_DOMAIN }}/health; then
+              echo "App is ready"
+              exit 0
+            fi
+            echo "Waiting..."
+            sleep 5
+          done
+
+          echo "App failed to start"
+          exit 1

--- a/knowledgeable/e2e/post-deploy/app.post-deploy.spec.js
+++ b/knowledgeable/e2e/post-deploy/app.post-deploy.spec.js
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('app loads', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('#navbar')).toBeVisible();
+});

--- a/knowledgeable/e2e/post-deploy/auth.post-deploy.spec.js
+++ b/knowledgeable/e2e/post-deploy/auth.post-deploy.spec.js
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('login works', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByLabel('Username').fill(process.env.TEST_USER_USERNAME);
+  await page.getByLabel('Password').fill(process.env.TEST_USER_PASSWORD);
+
+  await page.getByRole('button', { name: 'Log in' }).click();
+
+  await expect(page).toHaveURL(/\/$/, { timeout: 10000 });
+  
+});

--- a/knowledgeable/e2e/post-deploy/health.post-deploy.spec.js
+++ b/knowledgeable/e2e/post-deploy/health.post-deploy.spec.js
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke health endpoint returns ok', async ({ request }) => {
+  const res = await request.get('/health');
+
+  expect(res.status()).toBe(200);
+
+  const body = await res.text();
+  expect(body.trim()).toBe('ok');
+});

--- a/knowledgeable/e2e/post-deploy/search.post-deploy.spec.js
+++ b/knowledgeable/e2e/post-deploy/search.post-deploy.spec.js
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke search works', async ({ page }) => {
+  await page.goto('/search');
+
+  await page.getByPlaceholder('Search...').fill('g');
+  await page.click('#search-button');
+
+  const results = page.locator('#results a');
+
+  await expect(results.first()).toBeVisible({ timeout: 10000 });
+});


### PR DESCRIPTION
## What
What has been implemented?
Added a rollback step to the deployment workflow.
If the deploy or post-deploy smoke tests fail, the previous version is automatically restored by copying .env.previous back to .env and running docker compose again.

## Why
Why is this change needed?
To avoid leaving production in a broken state after a failed deployment.
The system can now automatically recover to the last known working version without manual intervention.
## Related Issue
Closes #319 

## Type 
- [x] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [x] Tests added (if relevant)