### PR TITLE
chore(promtail): removed path from promtail-config

### DIFF
--- a/ansible/templates/promtail-config.yml.j2
+++ b/ansible/templates/promtail-config.yml.j2
@@ -17,8 +17,6 @@ scrape_configs:
       - source_labels: ['__meta_docker_container_name']
         regex: '/(.*)'
         target_label: 'container'
-      - source_labels: ['__meta_docker_container_log_path']
-        target_label: '__path__'
       - source_labels: ['__meta_docker_container_name']
         regex: '/(.*)'
         target_label: 'instance'


### PR DESCRIPTION
## What
¨removed path from promtail-config

## Why
for promatail to tfetch app-app-1

## Related Issue
Closes #

## Type 
- [] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Promtail logging configuration for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->