### PR TITLE
Chore/enable known hosts

### DIFF
--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -23,6 +23,9 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
+          printf '%s\n' "${{ secrets.SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          printf '%s\n' "${{ secrets.MONITOR_SSH_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
 
       - name: Install Ansible
         run: |
@@ -41,6 +44,4 @@ jobs:
 
       - name: Run Ansible playbook
         working-directory: ansible
-        env:
-          ANSIBLE_HOST_KEY_CHECKING: "False"
         run: ansible-playbook -i inventory.ini playbook.yml

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -13,24 +13,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Add SSH key
+      - name: Setup SSH
         run: |
-          mkdir -p ~/.ssh/
+          mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/ssh_key
           chmod 600 ~/.ssh/ssh_key
+          printf '%s\n' "${{ secrets.SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
 
       - name: Copy compose file
         run: |
-          scp -i ~/.ssh/ssh_key -o StrictHostKeyChecking=no \
+          scp -i ~/.ssh/ssh_key \
             knowledgeable/docker-compose-staging.yml \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/app/docker-compose-staging.yml
 
       - name: Copy scripts
         run: |
-          scp -i ~/.ssh/ssh_key -o StrictHostKeyChecking=no \
+          scp -i ~/.ssh/ssh_key \
             .github/scripts/deploy-staging.sh \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/app/deploy-staging.sh
-          scp -i ~/.ssh/ssh_key -o StrictHostKeyChecking=no \
+          scp -i ~/.ssh/ssh_key \
             .github/scripts/teardown-staging.sh \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/app/teardown-staging.sh
 
@@ -51,14 +53,14 @@ jobs:
 
       - name: Transfer staging env
         run: |
-          scp -i ~/.ssh/ssh_key -o StrictHostKeyChecking=no \
+          scp -i ~/.ssh/ssh_key \
             .env.staging \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:~/app/.env.staging
           rm -f .env.staging
 
       - name: Deploy staging
         run: |
-          ssh -i ~/.ssh/ssh_key -o StrictHostKeyChecking=no \
+          ssh -i ~/.ssh/ssh_key \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} << "EOF"
             set -e
             echo "${{ secrets.CR__PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin

--- a/.github/workflows/monitoring-deployment.yml
+++ b/.github/workflows/monitoring-deployment.yml
@@ -15,24 +15,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Add SSH key
+      - name: Setup SSH
         run: |
-          mkdir -p ~/.ssh/
+          mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/ssh_key
           chmod 600 ~/.ssh/ssh_key
+          printf '%s\n' "${{ secrets.MONITOR_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
 
       - name: Copy monitoring stack
         run: |
-          ssh -i ~/.ssh/ssh_key -o StrictHostKeyChecking=no \
+          ssh -i ~/.ssh/ssh_key \
             ${{ secrets.SSH_USER }}@${{ secrets.MONITOR_SSH_HOST }} \
             "mkdir -p ~/monitoring"
-          scp -i ~/.ssh/ssh_key -o StrictHostKeyChecking=no -r \
+          scp -i ~/.ssh/ssh_key -r \
             monitoring/. \
             ${{ secrets.SSH_USER }}@${{ secrets.MONITOR_SSH_HOST }}:~/monitoring/
 
       - name: Write .env on remote
         run: |
-          ssh -i ~/.ssh/ssh_key -o StrictHostKeyChecking=no \
+          ssh -i ~/.ssh/ssh_key \
             ${{ secrets.SSH_USER }}@${{ secrets.MONITOR_SSH_HOST }} \
             "cat > ~/monitoring/.env" << "EOF"
           GF_SECURITY_ADMIN_USER=${{ secrets.GF_ADMIN_USER }}

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 inventory = inventory.ini
-host_key_checking = False
+host_key_checking = True
 remote_user = azureuser
 private_key_file = ~/.ssh/id_rsa
 stdout_callback = ansible.builtin.default


### PR DESCRIPTION
## What
added ssh checking to both deplyment staging, monitoring and ansible

## Why
For security reasons. Without it, the server will accept anyone duirng the time of connection, and we are suscceptible to man in the middle attakcs
## Related Issue
Closes #

## Type 
- [] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced SSH security across deployment and configuration workflows by enabling host key verification for staging deployments, monitoring deployments, and Ansible execution. SSH connections now properly validate server identities instead of bypassing verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Knowledgeables/Knowledge/pull/356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->