### PR TITLE
chore(ansible): removed apt from drift-check and updated monitoring s…

### DIFF
--- a/ansible/tasks/packages.yml
+++ b/ansible/tasks/packages.yml
@@ -3,6 +3,7 @@
   ansible.builtin.apt:
     update_cache: yes
     cache_valid_time: 3600
+  when: not ansible_check_mode
 
 - name: Upgrade all packages
   ansible.builtin.apt:


### PR DESCRIPTION
…ecret

## What
added "not in ansible checkmode to updating packages on the servers

## Why
They are considered drifts, when they are updated, we dont wont that to be included

## Related Issue
Closes #

## Type 
- [] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)

