### PR TITLE
chore(c): removed gh_token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     env:
-      GO111MODULE: on
       GOPRIVATE: github.com/knowledgeables/*
-      GITHUB_AUTHENTICATION_TOKEN: ${{ secrets.CR__PAT }}
       POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
       POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
       DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     env:
-      GOPRIVATE: github.com/knowledgeables/*
       POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
       POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
       DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ ansible/group_vars/all.yml
 knowledgeable/nginx/certbot/conf/
 knowledgeable/nginx/certbot/conf/
 knowledgeable/nginx/certbot/www/
+
+# Graphify
+graphify-out


### PR DESCRIPTION
## What
removed 2 env´s Go11Module is depreceiated and comes standard with go 1.25
cr_pat maybe depreciated 

## Why
Why is this change needed?

## Related Issue
Closes #

## Type 
- [] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI workflow environment configuration
  * Updated .gitignore to exclude additional build artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->