### PR TITLE
chore(workflow): refactored monitoring to run after ansible

### DIFF
--- a/.github/workflows/monitoring-deployment.yml
+++ b/.github/workflows/monitoring-deployment.yml
@@ -1,11 +1,11 @@
 name: CD - Monitoring Deployment
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Configure - Ansible"]
+    types:
+      - completed
     branches: [main]
-    paths:
-      - 'monitoring/**'
-      - '.github/workflows/deploy-monitoring.yml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What
changed the depends on in monitoring deployment to run after ansible

## Why
to avoid conflicts from folders 

## Related Issue
Closes #

## Type 
- [] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)

