### PR TITLE
chore(loki): added mem-cap on loki, edited restart on blackbox handler

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -43,7 +43,9 @@
     - name: Setup Blackbox exporter
       ansible.builtin.import_tasks: tasks/blackbox.yml
   handlers:
-    - name: Restart monitoring stack
-      community.docker.docker_compose_v2:
-        project_src: /home/azureuser/monitoring
-        state: restarted
+  - name: Restart blackbox exporter
+    community.docker.docker_compose_v2:
+      project_src: /home/azureuser/monitoring
+      services:
+        - blackbox-exporter
+      state: restarted

--- a/ansible/tasks/blackbox.yml
+++ b/ansible/tasks/blackbox.yml
@@ -10,4 +10,4 @@
     src: blackbox_config.yml.j2
     dest: /home/azureuser/monitoring/blackbox/config.yml
     mode: "0644"
-  notify: Restart monitoring stack
+  notify: Restart blackbox exporter

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -7,6 +7,8 @@ volumes:
   prometheus_data:
 services:
   loki:
+    mem_limit: 300m
+    memswap_limit: 500m
     image: grafana/loki:2.9.4
     container_name: loki
     volumes:

--- a/monitoring/loki/config.yaml
+++ b/monitoring/loki/config.yaml
@@ -3,6 +3,7 @@ auth_enabled: false
 server:
   http_listen_port: 3100
 
+
 ingester:
   wal:
     dir: /loki/wal
@@ -14,30 +15,19 @@ ingester:
   chunk_idle_period: 15m
   max_chunk_age: 30m
   chunk_retain_period: 1m
+  chunk_target_size: 512000        
+  chunk_encoding: snappy            
 
-schema_config:
-  configs:
-    - from: 2024-01-01
-      store: boltdb-shipper
-      object_store: filesystem
-      schema: v11
-      index:
-        prefix: index_
-        period: 24h
-
-storage_config:
-  boltdb_shipper:
-    active_index_directory: /loki/index
-    cache_location: /loki/cache
-    cache_ttl: 24h
-  filesystem:
-    directory: /loki/chunks
 
 limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 720h
-  max_query_parallelism: 2
-  max_entries_limit_per_query: 10000
+  max_query_parallelism: 1          
+  max_entries_limit_per_query: 5000  
+  ingestion_rate_mb: 4
+  ingestion_burst_size_mb: 6
+  max_streams_per_user: 1000       
 
-compactor:
-  working_directory: /loki/compactor
+
+query_range:
+  parallelise_shardable_queries: false


### PR DESCRIPTION
## What
added memory cap to loki and docker compose. 
edited handler in playbook to only restart blackbox

## Why
uptime efficiency

## Related Issue
Closes #

## Type 
- [] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added memory resource limits to the logging service to improve stability and resource management.
  * Optimized logging service configuration settings for better query performance, rate limiting, and stream controls.
  * Refined service restart behavior for monitoring components to be more targeted and efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->