### PR TITLE
chore(prometheus): changed logging days to 32 for SLA

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
-      - '--storage.tsdb.retention.time=15d'
+      - '--storage.tsdb.retention.time=32d'
     networks:
       - monitoring
     restart: unless-stopped


### PR DESCRIPTION
## What
Our SLA mentions 30 day uptime metrics, before we could only support 15 days.
data retention time is now 32 days

## Why
Support SLA

## Related Issue
Closes #

## Type 
- [] Feature
- [] Bug
- [x] Chore
- [] Docs

## Definition of Done
- [x] Code implemented
- [] Tests added (if relevant)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended Prometheus time-series data retention period from 15 days to 32 days for improved historical metrics availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->